### PR TITLE
feat(i18next): implement context and editing

### DIFF
--- a/packages/i18next/README.md
+++ b/packages/i18next/README.md
@@ -18,7 +18,7 @@
 
 ## Description
 
-An implementation of i18next's [filesystem backend] for Sapphire. It allows you to use a JSON-based `languages` directory to add internationalization for your bot using `SapphireClient`'s `fetchLanguage` hook and a custom message extension, adding features such as `sendTranslated` and `fetchLanguageKey`.
+An implementation of i18next's [filesystem backend] for Sapphire. It allows you to use a JSON-based `languages` directory to add internationalization for your bot using `SapphireClient`'s `fetchLanguage` hook and a custom message extension, adding features such as `sendTranslated` and `resolveKey`.
 
 [filesystem backend]: https://github.com/i18next/i18next-fs-backend
 
@@ -49,7 +49,7 @@ And for discord.js:
 import '@sapphire/plugin-i18next/register-discordjs';
 ```
 
-It is to be noted that unless you are using discord.js, which has the convenience register to extend the client and message methods for you, you will have to implement your own extensions.
+It is to be noted that unless you are using discord.js, which has the convenience register to extend the client, guild, channel and message methods for you, you will have to implement your own extensions.
 
 This is currently undocumented and not covered by guides, but will be in the future. For now, you may follow the structure of `register-discordjs.ts` if this is the case for you.
 

--- a/packages/i18next/src/index.ts
+++ b/packages/i18next/src/index.ts
@@ -1,2 +1,3 @@
 export * from './lib/types/options';
+export * from './lib/types/context';
 export * from './lib/I18nextHandler';

--- a/packages/i18next/src/lib/I18nextHandler.ts
+++ b/packages/i18next/src/lib/I18nextHandler.ts
@@ -23,7 +23,10 @@ export class I18nextHandler {
 	 */
 	public readonly languages = new Map<string, TFunction>();
 
-	private readonly options?: I18nOptions;
+	/**
+	 * The options I18nextHandler was initialized with in the client.
+	 */
+	public readonly options?: I18nOptions;
 
 	private readonly languagesDir: string;
 	private readonly backendOptions: i18nextFsBackend.i18nextFsBackendOptions;

--- a/packages/i18next/src/lib/types/context.ts
+++ b/packages/i18next/src/lib/types/context.ts
@@ -1,9 +1,13 @@
+export interface I18nGuildContext {};
+export interface I18nChannelContext {};
+export interface I18nAuthorContext {};
+
 /**
  * Context for fetchLanguage functions.
  * This context enables implementation of per-guild, per-channel, and per-user localisation.
  */
 export interface I18nContext {
-	guild: Record<string, unknown> | undefined;
-	channel: Record<string, unknown> | undefined;
-	author: Record<string, unknown> | undefined;
+	guild?: I18nGuildContext;
+	channel?: I18nChannelContext;
+	author?: I18nAuthorContext;
 }

--- a/packages/i18next/src/lib/types/context.ts
+++ b/packages/i18next/src/lib/types/context.ts
@@ -1,0 +1,9 @@
+/**
+ * Context for fetchLanguage functions.
+ * This context enables implementation of per-guild, per-channel, and per-user localisation.
+ */
+export interface I18nContext {
+	guild: Record<string, unknown> | undefined;
+	channel: Record<string, unknown> | undefined;
+	author: Record<string, unknown> | undefined;
+}

--- a/packages/i18next/src/lib/types/context.ts
+++ b/packages/i18next/src/lib/types/context.ts
@@ -1,6 +1,6 @@
-export interface I18nGuildContext {};
-export interface I18nChannelContext {};
-export interface I18nAuthorContext {};
+export interface I18nGuildContext {}
+export interface I18nChannelContext {}
+export interface I18nAuthorContext {}
 
 /**
  * Context for fetchLanguage functions.

--- a/packages/i18next/src/lib/types/context.ts
+++ b/packages/i18next/src/lib/types/context.ts
@@ -1,5 +1,19 @@
+/**
+ * Context for the guild, used in fetchLanguage functions.
+ * Should be an extension of your framework's Guild object, or the corresponding I18n extension.
+ */
 export interface I18nGuildContext {}
+
+/**
+ * Context for the channel, used in fetchLanguage functions.
+ * Should be an extension of your framework's Channel object, or the corresponding I18n extension.
+ */
 export interface I18nChannelContext {}
+
+/**
+ * Context for the user sending a message, used in fetchLanguage functions.
+ * Should be an extension of your framework's User object, or the corresponding I18n extension.
+ */
 export interface I18nAuthorContext {}
 
 /**

--- a/packages/i18next/src/register-discordjs.ts
+++ b/packages/i18next/src/register-discordjs.ts
@@ -69,7 +69,77 @@ class I18nextMessage extends Structures.get('Message') {
 	}
 }
 
-class I18nextChannel extends Structures.get('TextChannel') {
+class I18nextTextChannel extends Structures.get('TextChannel') {
+	public async fetchLanguage(): Promise<string> {
+		return fetchLanguage.apply(this, [this, undefined, this.guild]);
+	}
+
+	public async fetchT(): Promise<TFunction> {
+		return this.client.i18n.fetchT(await this.fetchLanguage());
+	}
+
+	public async resolveKey(key: string, ...values: readonly any[]): Promise<string> {
+		return this.client.i18n.fetchLocale(await this.fetchLanguage(), key, ...values);
+	}
+
+	public sendTranslated(
+		key: string,
+		values?: readonly unknown[],
+		options?: MessageOptions | (MessageOptions & { split?: false }) | MessageAdditions
+	): Promise<Message>;
+
+	public sendTranslated(key: string, values?: readonly unknown[], options?: MessageOptions & { split: true | SplitOptions }): Promise<Message[]>;
+	public sendTranslated(key: string, options?: MessageOptions | (MessageOptions & { split?: false }) | MessageAdditions): Promise<Message>;
+	public sendTranslated(key: string, options?: MessageOptions & { split: true | SplitOptions }): Promise<Message[]>;
+	public async sendTranslated(
+		key: string,
+		valuesOrOptions?: readonly unknown[] | MessageOptions | MessageAdditions,
+		rawOptions?: MessageOptions
+	): Promise<Message | Message[]> {
+		const [values, options]: [readonly unknown[], MessageOptions] =
+			valuesOrOptions === undefined || Array.isArray(valuesOrOptions)
+				? [valuesOrOptions ?? [], rawOptions ?? {}]
+				: [[], valuesOrOptions as MessageOptions];
+		return this.send(await this.resolveKey(key, ...values), options);
+	}
+}
+
+class I18nextDMChannel extends Structures.get('DMChannel') {
+	public async fetchLanguage(): Promise<string> {
+		return fetchLanguage.apply(this, [this, undefined, undefined]);
+	}
+
+	public async fetchT(): Promise<TFunction> {
+		return this.client.i18n.fetchT(await this.fetchLanguage());
+	}
+
+	public async resolveKey(key: string, ...values: readonly any[]): Promise<string> {
+		return this.client.i18n.fetchLocale(await this.fetchLanguage(), key, ...values);
+	}
+
+	public sendTranslated(
+		key: string,
+		values?: readonly unknown[],
+		options?: MessageOptions | (MessageOptions & { split?: false }) | MessageAdditions
+	): Promise<Message>;
+
+	public sendTranslated(key: string, values?: readonly unknown[], options?: MessageOptions & { split: true | SplitOptions }): Promise<Message[]>;
+	public sendTranslated(key: string, options?: MessageOptions | (MessageOptions & { split?: false }) | MessageAdditions): Promise<Message>;
+	public sendTranslated(key: string, options?: MessageOptions & { split: true | SplitOptions }): Promise<Message[]>;
+	public async sendTranslated(
+		key: string,
+		valuesOrOptions?: readonly unknown[] | MessageOptions | MessageAdditions,
+		rawOptions?: MessageOptions
+	): Promise<Message | Message[]> {
+		const [values, options]: [readonly unknown[], MessageOptions] =
+			valuesOrOptions === undefined || Array.isArray(valuesOrOptions)
+				? [valuesOrOptions ?? [], rawOptions ?? {}]
+				: [[], valuesOrOptions as MessageOptions];
+		return this.send(await this.resolveKey(key, ...values), options);
+	}
+}
+
+class I18nextNewsChannel extends Structures.get('NewsChannel') {
 	public async fetchLanguage(): Promise<string> {
 		return fetchLanguage.apply(this, [this, undefined, this.guild]);
 	}
@@ -119,11 +189,13 @@ class I18nextGuild extends Structures.get('Guild') {
 }
 
 Structures.extend('Message', () => I18nextMessage);
-Structures.extend('TextChannel', () => I18nextChannel);
+Structures.extend('TextChannel', () => I18nextTextChannel);
+Structures.extend('DMChannel', () => I18nextDMChannel);
+Structures.extend('NewsChannel', () => I18nextNewsChannel);
 Structures.extend('Guild', () => I18nextGuild);
 
 declare module 'discord.js' {
-	interface Message {
+	export interface Message {
 		/**
 		 * Accessor for {@link I18nextPlugin#fetchLanguage} that implements an order of preference for locales.
 		 * @since 1.0.0
@@ -186,7 +258,7 @@ declare module 'discord.js' {
 		): Promise<Message | Message[]>;
 	}
 
-	interface Channel {
+	export interface Channel {
 		/**
 		 * Accessor for {@link I18nextPlugin#fetchLanguage} that implements an order of preference for locales.
 		 * @since 1.0.0
@@ -229,7 +301,7 @@ declare module 'discord.js' {
 		): Promise<Message | Message[]>;
 	}
 
-	interface Guild {
+	export interface Guild {
 		/**
 		 * Accessor for {@link I18nextPlugin#fetchLanguage} that implements an order of preference for locales.
 		 * @since 1.0.0

--- a/packages/i18next/src/register-discordjs.ts
+++ b/packages/i18next/src/register-discordjs.ts
@@ -36,7 +36,7 @@ class I18nextMessage extends Structures.get('Message') {
 			valuesOrOptions === undefined || Array.isArray(valuesOrOptions)
 				? [valuesOrOptions ?? [], rawOptions ?? {}]
 				: [[], valuesOrOptions as MessageOptions];
-		const content = await this.fetchLanguageKey(key, ...values);
+		const content = await this.resolveKey(key, ...values);
 		return this.channel.send(content, options);
 	}
 }
@@ -64,7 +64,7 @@ declare module 'discord.js' {
 		 * @since 1.0.0
 		 * @return A string, which is the translated result of the key, with templated values.
 		 */
-		fetchLanguageKey(key: string, ...values: readonly any[]): Promise<string>;
+		resolveKey(key: string, ...values: readonly any[]): Promise<string>;
 
 		/**
 		 * Function that sends a message to the context channel with the translated key and values.

--- a/packages/i18next/src/register-discordjs.ts
+++ b/packages/i18next/src/register-discordjs.ts
@@ -2,20 +2,26 @@ import './register';
 export * from './register';
 import type { TFunction } from 'i18next';
 import type { I18nextHandler, I18nOptions, I18nContext } from './index';
-import { Message, MessageAdditions, MessageOptions, SplitOptions, Structures, Channel, Guild, User } from 'discord.js';
+import { Message, MessageAdditions, MessageOptions, SplitOptions, Structures, Channel, Guild, User, Client } from 'discord.js';
 
-async function fetchLanguage(this: Message | Channel | Guild, channel?: Channel | null, author?: User | null, guild?: Guild | null): Promise<string> {
-	const lang = await this.client.fetchLanguage({
-		channel,
+declare module './index' {
+	export interface I18nGuildContext extends Guild {}
+	export interface I18nChannelContext extends Channel {}
+	export interface I18nAuthorContext extends Channel {}
+}
+
+async function fetchLanguage(client: Client, guild?: Guild | null, channel?: Channel | null, author?: User | null): Promise<string> {
+	const lang = await client.fetchLanguage({
 		guild,
+		channel,
 		author
 	} as I18nContext);
-	return lang ?? guild?.preferredLocale ?? this.client.i18n?.options?.defaultName ?? 'en-US';
+	return lang ?? guild?.preferredLocale ?? client.i18n?.options?.defaultName ?? 'en-US';
 }
 
 class I18nextMessage extends Structures.get('Message') {
 	public async fetchLanguage(): Promise<string> {
-		return fetchLanguage.apply(this, [this.channel, this.author, this.guild]);
+		return fetchLanguage(this.client, this.guild, this.channel, this.author);
 	}
 
 	public async fetchT(): Promise<TFunction> {
@@ -71,7 +77,7 @@ class I18nextMessage extends Structures.get('Message') {
 
 class I18nextTextChannel extends Structures.get('TextChannel') {
 	public async fetchLanguage(): Promise<string> {
-		return fetchLanguage.apply(this, [this, undefined, this.guild]);
+		return fetchLanguage(this.client, this.guild, this, undefined);
 	}
 
 	public async fetchT(): Promise<TFunction> {
@@ -106,7 +112,7 @@ class I18nextTextChannel extends Structures.get('TextChannel') {
 
 class I18nextDMChannel extends Structures.get('DMChannel') {
 	public async fetchLanguage(): Promise<string> {
-		return fetchLanguage.apply(this, [this, undefined, undefined]);
+		return fetchLanguage(this.client, undefined, this, undefined);
 	}
 
 	public async fetchT(): Promise<TFunction> {
@@ -141,7 +147,7 @@ class I18nextDMChannel extends Structures.get('DMChannel') {
 
 class I18nextNewsChannel extends Structures.get('NewsChannel') {
 	public async fetchLanguage(): Promise<string> {
-		return fetchLanguage.apply(this, [this, undefined, this.guild]);
+		return fetchLanguage(this.client, this.guild, this, undefined);
 	}
 
 	public async fetchT(): Promise<TFunction> {
@@ -176,7 +182,7 @@ class I18nextNewsChannel extends Structures.get('NewsChannel') {
 
 class I18nextGuild extends Structures.get('Guild') {
 	public async fetchLanguage(): Promise<string> {
-		return fetchLanguage.apply(this, [undefined, undefined, this]);
+		return fetchLanguage(this.client, this, undefined, undefined);
 	}
 
 	public async fetchT(): Promise<TFunction> {

--- a/packages/i18next/src/register-discordjs.ts
+++ b/packages/i18next/src/register-discordjs.ts
@@ -1,13 +1,21 @@
 import './register';
 export * from './register';
 import type { TFunction } from 'i18next';
-import type { I18nextHandler, I18nOptions } from './index';
-import { Message, MessageAdditions, MessageOptions, SplitOptions, Structures } from 'discord.js';
+import type { I18nextHandler, I18nOptions, I18nContext } from './index';
+import { Message, MessageAdditions, MessageOptions, SplitOptions, Structures, Channel, Guild, User } from 'discord.js';
+
+async function fetchLanguage(this: Message | Channel | Guild, channel?: Channel | null, author?: User | null, guild?: Guild | null): Promise<string> {
+	const lang = await this.client.fetchLanguage({
+		channel,
+		guild,
+		author
+	} as I18nContext);
+	return lang ?? guild?.preferredLocale ?? this.client.i18n?.options?.defaultName ?? 'en-US';
+}
 
 class I18nextMessage extends Structures.get('Message') {
 	public async fetchLanguage(): Promise<string> {
-		const lang = await this.client.fetchLanguage(this);
-		return lang ?? this.guild?.preferredLocale ?? this.client.options.i18n?.defaultName ?? 'en-US';
+		return fetchLanguage.apply(this, [this.channel, this.author, this.guild]);
 	}
 
 	public async fetchT(): Promise<TFunction> {
@@ -18,33 +26,101 @@ class I18nextMessage extends Structures.get('Message') {
 		return this.client.i18n.fetchLocale(await this.fetchLanguage(), key, ...values);
 	}
 
-	public translated(
+	public replyTranslated(
 		key: string,
 		values?: readonly unknown[],
-		options?: MessageOptions | (MessageOptions & { split?: false }) | MessageAdditions,
-		edit?: boolean
+		options?: MessageOptions | (MessageOptions & { split?: false }) | MessageAdditions
 	): Promise<Message>;
 
-	public translated(key: string, values?: readonly unknown[], options?: MessageOptions & { split: true | SplitOptions }): Promise<Message[]>;
-	public translated(key: string, options?: MessageOptions | (MessageOptions & { split?: false }) | MessageAdditions): Promise<Message>;
-	public translated(key: string, options?: MessageOptions & { split: true | SplitOptions }): Promise<Message[]>;
-	public async translated(
+	public replyTranslated(key: string, values?: readonly unknown[], options?: MessageOptions & { split: true | SplitOptions }): Promise<Message[]>;
+	public replyTranslated(key: string, options?: MessageOptions | (MessageOptions & { split?: false }) | MessageAdditions): Promise<Message>;
+	public replyTranslated(key: string, options?: MessageOptions & { split: true | SplitOptions }): Promise<Message[]>;
+	public async replyTranslated(
 		key: string,
 		valuesOrOptions?: readonly unknown[] | MessageOptions | MessageAdditions,
-		rawOptions?: MessageOptions,
-		edit?: boolean
+		rawOptions?: MessageOptions
 	): Promise<Message | Message[]> {
 		const [values, options]: [readonly unknown[], MessageOptions] =
 			valuesOrOptions === undefined || Array.isArray(valuesOrOptions)
 				? [valuesOrOptions ?? [], rawOptions ?? {}]
 				: [[], valuesOrOptions as MessageOptions];
-		const content = await this.resolveKey(key, ...values);
-		if (edit) return this.edit(content, options);
-		return this.channel.send(content, options);
+		return this.reply(await this.resolveKey(key, ...values), options);
+	}
+
+	public editTranslated(
+		key: string,
+		values?: readonly unknown[],
+		options?: MessageOptions | (MessageOptions & { split?: false }) | MessageAdditions
+	): Promise<Message>;
+
+	public editTranslated(key: string, values?: readonly unknown[], options?: MessageOptions & { split: true | SplitOptions }): Promise<Message[]>;
+	public editTranslated(key: string, options?: MessageOptions | (MessageOptions & { split?: false }) | MessageAdditions): Promise<Message>;
+	public editTranslated(key: string, options?: MessageOptions & { split: true | SplitOptions }): Promise<Message[]>;
+	public async editTranslated(
+		key: string,
+		valuesOrOptions?: readonly unknown[] | MessageOptions | MessageAdditions,
+		rawOptions?: MessageOptions
+	): Promise<Message | Message[]> {
+		const [values, options]: [readonly unknown[], MessageOptions] =
+			valuesOrOptions === undefined || Array.isArray(valuesOrOptions)
+				? [valuesOrOptions ?? [], rawOptions ?? {}]
+				: [[], valuesOrOptions as MessageOptions];
+		return this.edit(await this.resolveKey(key, ...values), options);
+	}
+}
+
+class I18nextChannel extends Structures.get('TextChannel') {
+	public async fetchLanguage(): Promise<string> {
+		return fetchLanguage.apply(this, [this, undefined, this.guild]);
+	}
+
+	public async fetchT(): Promise<TFunction> {
+		return this.client.i18n.fetchT(await this.fetchLanguage());
+	}
+
+	public async resolveKey(key: string, ...values: readonly any[]): Promise<string> {
+		return this.client.i18n.fetchLocale(await this.fetchLanguage(), key, ...values);
+	}
+
+	public sendTranslated(
+		key: string,
+		values?: readonly unknown[],
+		options?: MessageOptions | (MessageOptions & { split?: false }) | MessageAdditions
+	): Promise<Message>;
+
+	public sendTranslated(key: string, values?: readonly unknown[], options?: MessageOptions & { split: true | SplitOptions }): Promise<Message[]>;
+	public sendTranslated(key: string, options?: MessageOptions | (MessageOptions & { split?: false }) | MessageAdditions): Promise<Message>;
+	public sendTranslated(key: string, options?: MessageOptions & { split: true | SplitOptions }): Promise<Message[]>;
+	public async sendTranslated(
+		key: string,
+		valuesOrOptions?: readonly unknown[] | MessageOptions | MessageAdditions,
+		rawOptions?: MessageOptions
+	): Promise<Message | Message[]> {
+		const [values, options]: [readonly unknown[], MessageOptions] =
+			valuesOrOptions === undefined || Array.isArray(valuesOrOptions)
+				? [valuesOrOptions ?? [], rawOptions ?? {}]
+				: [[], valuesOrOptions as MessageOptions];
+		return this.send(await this.resolveKey(key, ...values), options);
+	}
+}
+
+class I18nextGuild extends Structures.get('Guild') {
+	public async fetchLanguage(): Promise<string> {
+		return fetchLanguage.apply(this, [undefined, undefined, this]);
+	}
+
+	public async fetchT(): Promise<TFunction> {
+		return this.client.i18n.fetchT(await this.fetchLanguage());
+	}
+
+	public async resolveKey(key: string, ...values: readonly any[]): Promise<string> {
+		return this.client.i18n.fetchLocale(await this.fetchLanguage(), key, ...values);
 	}
 }
 
 Structures.extend('Message', () => I18nextMessage);
+Structures.extend('TextChannel', () => I18nextChannel);
+Structures.extend('Guild', () => I18nextGuild);
 
 declare module 'discord.js' {
 	interface Message {
@@ -70,27 +146,110 @@ declare module 'discord.js' {
 		resolveKey(key: string, ...values: readonly any[]): Promise<string>;
 
 		/**
-		 * Function that sends or edits a message for the context channel with the translated key and values.
-		 * Functionally equivalent to piping fetchLanguageKey through channel#send or message#edit.
+		 * Function that sends a response message for the context channel with the translated key and values.
+		 * Functionally equivalent to piping resolveKey through Message#reply.
 		 * @since 1.0.0
-		 * @return The message object that was sent or edited.
-		 * @param edit Whether to attempt to edit the message object or send a new one.
+		 * @return The message object that was sent.
 		 */
-		translated(
+		replyTranslated(
 			key: string,
 			values?: readonly unknown[],
-			options?: MessageOptions | (MessageOptions & { split?: false }) | MessageAdditions,
-			edit?: boolean
+			options?: MessageOptions | (MessageOptions & { split?: false }) | MessageAdditions
 		): Promise<Message>;
-		translated(key: string, values?: readonly unknown[], options?: MessageOptions & { split: true | SplitOptions }): Promise<Message[]>;
-		translated(key: string, options?: MessageOptions | (MessageOptions & { split?: false }) | MessageAdditions): Promise<Message>;
-		translated(key: string, options?: MessageOptions & { split: true | SplitOptions }): Promise<Message[]>;
-		translated(
+		replyTranslated(key: string, values?: readonly unknown[], options?: MessageOptions & { split: true | SplitOptions }): Promise<Message[]>;
+		replyTranslated(key: string, options?: MessageOptions | (MessageOptions & { split?: false }) | MessageAdditions): Promise<Message>;
+		replyTranslated(key: string, options?: MessageOptions & { split: true | SplitOptions }): Promise<Message[]>;
+		replyTranslated(
 			key: string,
 			valuesOrOptions?: readonly unknown[] | MessageOptions | MessageAdditions,
-			rawOptions?: MessageOptions,
-			edit?: boolean
+			rawOptions?: MessageOptions
 		): Promise<Message | Message[]>;
+
+		/**
+		 * Function that edits a message with the translated key and values.
+		 * Functionally equivalent to piping resolveKey through Message#edit.
+		 * @since 1.0.0
+		 * @return The message object that was edited.
+		 */
+		editTranslated(
+			key: string,
+			values?: readonly unknown[],
+			options?: MessageOptions | (MessageOptions & { split?: false }) | MessageAdditions
+		): Promise<Message>;
+		editTranslated(key: string, values?: readonly unknown[], options?: MessageOptions & { split: true | SplitOptions }): Promise<Message[]>;
+		editTranslated(key: string, options?: MessageOptions | (MessageOptions & { split?: false }) | MessageAdditions): Promise<Message>;
+		editTranslated(key: string, options?: MessageOptions & { split: true | SplitOptions }): Promise<Message[]>;
+		editTranslated(
+			key: string,
+			valuesOrOptions?: readonly unknown[] | MessageOptions | MessageAdditions,
+			rawOptions?: MessageOptions
+		): Promise<Message | Message[]>;
+	}
+
+	interface Channel {
+		/**
+		 * Accessor for {@link I18nextPlugin#fetchLanguage} that implements an order of preference for locales.
+		 * @since 1.0.0
+		 * @return In preference order, {@link I18nextPlugin#fetchLanguage} -> the guild's preferredLocale -> {@link I18nextOptions#defaultName} -> 'en-US'.
+		 */
+		fetchLanguage(): Promise<string>;
+
+		/**
+		 * Function that gets a TFunction (translator function) from i18next.
+		 * @since 1.0.0
+		 * @return An i18next TFunction.
+		 */
+		fetchT(): Promise<TFunction>;
+
+		/**
+		 * Function that resolves a language key from the store.
+		 * @since 1.0.0
+		 * @return A string, which is the translated result of the key, with templated values.
+		 */
+		resolveKey(key: string, ...values: readonly any[]): Promise<string>;
+
+		/**
+		 * Function that sends a message for the channel with the translated key and values.
+		 * Functionally equivalent to piping resolveKey through Channel#send.
+		 * @since 1.0.0
+		 * @return The message object that was sent.
+		 */
+		sendTranslated(
+			key: string,
+			values?: readonly unknown[],
+			options?: MessageOptions | (MessageOptions & { split?: false }) | MessageAdditions
+		): Promise<Message>;
+		sendTranslated(key: string, values?: readonly unknown[], options?: MessageOptions & { split: true | SplitOptions }): Promise<Message[]>;
+		sendTranslated(key: string, options?: MessageOptions | (MessageOptions & { split?: false }) | MessageAdditions): Promise<Message>;
+		sendTranslated(key: string, options?: MessageOptions & { split: true | SplitOptions }): Promise<Message[]>;
+		sendTranslated(
+			key: string,
+			valuesOrOptions?: readonly unknown[] | MessageOptions | MessageAdditions,
+			rawOptions?: MessageOptions
+		): Promise<Message | Message[]>;
+	}
+
+	interface Guild {
+		/**
+		 * Accessor for {@link I18nextPlugin#fetchLanguage} that implements an order of preference for locales.
+		 * @since 1.0.0
+		 * @return In preference order, {@link I18nextPlugin#fetchLanguage} -> the guild's preferredLocale -> {@link I18nextOptions#defaultName} -> 'en-US'.
+		 */
+		fetchLanguage(): Promise<string>;
+
+		/**
+		 * Function that gets a TFunction (translator function) from i18next.
+		 * @since 1.0.0
+		 * @return An i18next TFunction.
+		 */
+		fetchT(): Promise<TFunction>;
+
+		/**
+		 * Function that resolves a language key from the store.
+		 * @since 1.0.0
+		 * @return A string, which is the translated result of the key, with templated values.
+		 */
+		resolveKey(key: string, ...values: readonly any[]): Promise<string>;
 	}
 
 	export interface Client {
@@ -129,7 +288,7 @@ declare module 'discord.js' {
 		 * };
 		 * ```
 		 */
-		fetchLanguage: (message: any) => Promise<string | null> | string | null;
+		fetchLanguage: (context: I18nContext) => Promise<string | null> | string | null;
 	}
 
 	export interface ClientOptions {
@@ -144,6 +303,6 @@ declare module 'discord.js' {
 		 * @since 1.0.0
 		 * @default () => client.options.defaultLanguage
 		 */
-		fetchLanguage?: (message: any) => Promise<string | null> | string | null;
+		fetchLanguage?: (context: I18nContext) => Promise<string | null> | string | null;
 	}
 }

--- a/packages/i18next/src/register-discordjs.ts
+++ b/packages/i18next/src/register-discordjs.ts
@@ -22,7 +22,7 @@ class I18nextMessage extends Structures.get('Message') {
 		key: string,
 		values?: readonly unknown[],
 		options?: MessageOptions | (MessageOptions & { split?: false }) | MessageAdditions,
-		edit?: Boolean
+		edit?: boolean
 	): Promise<Message>;
 
 	public translated(key: string, values?: readonly unknown[], options?: MessageOptions & { split: true | SplitOptions }): Promise<Message[]>;
@@ -32,7 +32,7 @@ class I18nextMessage extends Structures.get('Message') {
 		key: string,
 		valuesOrOptions?: readonly unknown[] | MessageOptions | MessageAdditions,
 		rawOptions?: MessageOptions,
-		edit?: Boolean
+		edit?: boolean
 	): Promise<Message | Message[]> {
 		const [values, options]: [readonly unknown[], MessageOptions] =
 			valuesOrOptions === undefined || Array.isArray(valuesOrOptions)
@@ -80,7 +80,7 @@ declare module 'discord.js' {
 			key: string,
 			values?: readonly unknown[],
 			options?: MessageOptions | (MessageOptions & { split?: false }) | MessageAdditions,
-			edit?: Boolean
+			edit?: boolean
 		): Promise<Message>;
 		translated(key: string, values?: readonly unknown[], options?: MessageOptions & { split: true | SplitOptions }): Promise<Message[]>;
 		translated(key: string, options?: MessageOptions | (MessageOptions & { split?: false }) | MessageAdditions): Promise<Message>;
@@ -89,7 +89,7 @@ declare module 'discord.js' {
 			key: string,
 			valuesOrOptions?: readonly unknown[] | MessageOptions | MessageAdditions,
 			rawOptions?: MessageOptions,
-			edit?: Boolean
+			edit?: boolean
 		): Promise<Message | Message[]>;
 	}
 

--- a/packages/i18next/src/register-discordjs.ts
+++ b/packages/i18next/src/register-discordjs.ts
@@ -18,25 +18,28 @@ class I18nextMessage extends Structures.get('Message') {
 		return this.client.i18n.fetchLocale(await this.fetchLanguage(), key, ...values);
 	}
 
-	public sendTranslated(
+	public translated(
 		key: string,
 		values?: readonly unknown[],
-		options?: MessageOptions | (MessageOptions & { split?: false }) | MessageAdditions
+		options?: MessageOptions | (MessageOptions & { split?: false }) | MessageAdditions,
+		edit?: Boolean
 	): Promise<Message>;
 
-	public sendTranslated(key: string, values?: readonly unknown[], options?: MessageOptions & { split: true | SplitOptions }): Promise<Message[]>;
-	public sendTranslated(key: string, options?: MessageOptions | (MessageOptions & { split?: false }) | MessageAdditions): Promise<Message>;
-	public sendTranslated(key: string, options?: MessageOptions & { split: true | SplitOptions }): Promise<Message[]>;
-	public async sendTranslated(
+	public translated(key: string, values?: readonly unknown[], options?: MessageOptions & { split: true | SplitOptions }): Promise<Message[]>;
+	public translated(key: string, options?: MessageOptions | (MessageOptions & { split?: false }) | MessageAdditions): Promise<Message>;
+	public translated(key: string, options?: MessageOptions & { split: true | SplitOptions }): Promise<Message[]>;
+	public async translated(
 		key: string,
 		valuesOrOptions?: readonly unknown[] | MessageOptions | MessageAdditions,
-		rawOptions?: MessageOptions
+		rawOptions?: MessageOptions,
+		edit?: Boolean
 	): Promise<Message | Message[]> {
 		const [values, options]: [readonly unknown[], MessageOptions] =
 			valuesOrOptions === undefined || Array.isArray(valuesOrOptions)
 				? [valuesOrOptions ?? [], rawOptions ?? {}]
 				: [[], valuesOrOptions as MessageOptions];
 		const content = await this.resolveKey(key, ...values);
+		if (edit) return this.edit(content, options);
 		return this.channel.send(content, options);
 	}
 }
@@ -67,23 +70,26 @@ declare module 'discord.js' {
 		resolveKey(key: string, ...values: readonly any[]): Promise<string>;
 
 		/**
-		 * Function that sends a message to the context channel with the translated key and values.
-		 * Functionally equivalent to piping fetchLanguageKey through channel#send.
+		 * Function that sends or edits a message for the context channel with the translated key and values.
+		 * Functionally equivalent to piping fetchLanguageKey through channel#send or message#edit.
 		 * @since 1.0.0
-		 * @return The message object that was sent.
+		 * @return The message object that was sent or edited.
+		 * @param edit Whether to attempt to edit the message object or send a new one.
 		 */
-		sendTranslated(
+		translated(
 			key: string,
 			values?: readonly unknown[],
-			options?: MessageOptions | (MessageOptions & { split?: false }) | MessageAdditions
+			options?: MessageOptions | (MessageOptions & { split?: false }) | MessageAdditions,
+			edit?: Boolean
 		): Promise<Message>;
-		sendTranslated(key: string, values?: readonly unknown[], options?: MessageOptions & { split: true | SplitOptions }): Promise<Message[]>;
-		sendTranslated(key: string, options?: MessageOptions | (MessageOptions & { split?: false }) | MessageAdditions): Promise<Message>;
-		sendTranslated(key: string, options?: MessageOptions & { split: true | SplitOptions }): Promise<Message[]>;
-		sendTranslated(
+		translated(key: string, values?: readonly unknown[], options?: MessageOptions & { split: true | SplitOptions }): Promise<Message[]>;
+		translated(key: string, options?: MessageOptions | (MessageOptions & { split?: false }) | MessageAdditions): Promise<Message>;
+		translated(key: string, options?: MessageOptions & { split: true | SplitOptions }): Promise<Message[]>;
+		translated(
 			key: string,
 			valuesOrOptions?: readonly unknown[] | MessageOptions | MessageAdditions,
-			rawOptions?: MessageOptions
+			rawOptions?: MessageOptions,
+			edit?: Boolean
 		): Promise<Message | Message[]>;
 	}
 

--- a/packages/i18next/src/register.ts
+++ b/packages/i18next/src/register.ts
@@ -1,5 +1,5 @@
 import { Plugin, preGenericsInitialization, preLogin, SapphireClient, SapphireClientOptions } from '@sapphire/framework';
-import { I18nextHandler, I18nOptions } from './index';
+import { I18nextHandler, I18nOptions, I18nContext } from './index';
 
 export class I18nextPlugin extends Plugin {
 	public static [preGenericsInitialization](this: SapphireClient, options: SapphireClientOptions): void {
@@ -21,7 +21,7 @@ declare module '@sapphire/framework' {
 		 * The method to be overriden by the developer.
 		 * Note: In the event that fetchLanguage is not defined or returns null or undefined
 		 * the order of defaulting will be as follows:
-		 * client.fetchLanguage -> message.guild.preferredLocale -> this.client.options.i18n.defaultName -> 'en-US'
+		 * client.fetchLanguage -> guild.preferredLocale -> client.options.i18n.defaultName -> 'en-US'
 		 * @since 1.0.0
 		 * @return A string for the desired language or null for no match.
 		 * @example
@@ -31,22 +31,30 @@ declare module '@sapphire/framework' {
 		 * ```
 		 * @example
 		 * ```typescript
-		 * // Retrieving the prefix from an SQL database:
-		 * client.fetchLanguage = async (message) => {
-		 *   const guild = await driver.getOne('SELECT language FROM public.guild WHERE id = $1', [message.guild.id]);
+		 * // Retrieving the language from an SQL database:
+		 * client.fetchLanguage = async (context) => {
+		 *   const guild = await driver.getOne('SELECT language FROM public.guild WHERE id = $1', [context.guild.id]);
 		 *   return guild?.language ?? 'en-US';
 		 * };
 		 * ```
 		 * @example
 		 * ```typescript
 		 * // Retrieving the language from an ORM:
-		 * client.fetchLanguage = async (message) => {
-		 *   const guild = await driver.getRepository(GuildEntity).findOne({ id: message.guild.id });
+		 * client.fetchLanguage = async (context) => {
+		 *   const guild = await driver.getRepository(GuildEntity).findOne({ id: context.guild.id });
 		 *   return guild?.language ?? 'en-US';
 		 * };
 		 * ```
+		 * @example
+		 * ```typescript
+		 * // Retrieving the language on a per channel basis, e.g. per user or guild channel (ORM example but same principles apply):
+		 * client.fetchLanguage = async (context) => {
+		 *   const channel = await driver.getRepository(ChannelEntity).findOne({ id: context.channel.id });
+		 *   return channel?.language ?? 'en-US';
+		 * };
+		 * ```
 		 */
-		fetchLanguage: (message: any) => Promise<string | null> | string | null;
+		fetchLanguage: (context: I18nContext) => Promise<string | null> | string | null;
 	}
 
 	export interface SapphireClientOptions {
@@ -57,7 +65,7 @@ declare module '@sapphire/framework' {
 		 * @since 1.0.0
 		 * @default () => client.options.defaultLanguage
 		 */
-		fetchLanguage?: (message: any) => Promise<string | null> | string | null;
+		fetchLanguage?: (context: I18nContext) => Promise<string | null> | string | null;
 	}
 }
 


### PR DESCRIPTION
This fixes the naming error previously found in i18next and also adds editing functionality.

CHANGES:
- `Message#sendTranslated` -> `Message#translated` (BREAKING)
- New optional argument for `Message#translated`: `edit` (boolean)