### PR TITLE
refactor(i18next): docs and standardize implementation features

### DIFF
--- a/packages/i18next/src/index.ts
+++ b/packages/i18next/src/index.ts
@@ -1,3 +1,2 @@
-export * from './lib/types/options';
-export * from './lib/types/context';
-export * from './lib/I18nextHandler';
+export * from './lib/types/index';
+export * from './lib/index';

--- a/packages/i18next/src/lib/I18nextImplementation.ts
+++ b/packages/i18next/src/lib/I18nextImplementation.ts
@@ -1,0 +1,63 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+import type { TFunction } from 'i18next';
+import type { I18nextClient, I18nextBaseImplementation, I18nContext, I18nGuildContext, I18nChannelContext, I18nAuthorContext } from './types/index';
+
+type Ctor = new (...args: any[]) => { client: I18nextClient };
+
+/**
+ * @since 1.0.0
+ * @returns An I18nextImplementation mixin which extends the Base parameter and fully implements {@link I18nextBaseImplementation}.
+ * @param Base The class to use as the base for the implementation (e.g. a Discord library's Message object)
+ */
+export function I18nextImplemented<BaseClass extends Ctor>(Base: BaseClass) {
+	/**
+	 * The class that defines the base / default implementations of the plugin.
+	 * This class is used to extend the {@link I18nContext} objects for registers.
+	 * @since 1.0.0
+	 **/
+	return class I18nextImplementation extends Base implements I18nextBaseImplementation {
+		/**
+		 * Accessor for {@link I18nextClient.fetchLanguage} with context applied.
+		 * To use this in an implementation, create a new function called `fetchLanguage` and execute this with context applied.
+		 * This can be overwritten if you want to specify a different order of defaulting.
+		 * @since 1.0.0
+		 * @see {@link I18nextBaseImplementation.fetchLanguage}
+		 **/
+		public async _fetchLanguage(
+			guild?: I18nGuildContext | null,
+			channel?: I18nChannelContext | null,
+			author?: I18nAuthorContext | null
+		): Promise<string> {
+			const lang = await this.client.fetchLanguage({
+				guild,
+				channel,
+				author
+			} as I18nContext);
+			return lang ?? guild?.preferredLocale ?? this.client.i18n?.options?.defaultName ?? 'en-US';
+		}
+
+		/**
+		 * Method to be overwritten to apply context to {@link I18nextImplementation._fetchLanguage}
+		 * @since 1.0.0
+		 */
+		public async fetchLanguage(): Promise<string> {
+			return this._fetchLanguage();
+		}
+
+		/**
+		 * @since 1.0.0
+		 * @see {@link I18nextBaseImplementation.resolveKey}
+		 */
+		public async fetchT(): Promise<TFunction> {
+			return this.client.i18n.fetchT(await this.fetchLanguage());
+		}
+
+		/**
+		 * @since 1.0.0
+		 * @see {@link I18nextBaseImplementation.resolveKey}
+		 */
+		public async resolveKey(key: string, ...values: readonly any[]): Promise<string> {
+			return this.client.i18n.fetchLocale(await this.fetchLanguage(), key, ...values);
+		}
+	};
+}

--- a/packages/i18next/src/lib/index.ts
+++ b/packages/i18next/src/lib/index.ts
@@ -1,0 +1,2 @@
+export * from './I18nextHandler';
+export * from './I18nextImplementation';

--- a/packages/i18next/src/lib/types/client.ts
+++ b/packages/i18next/src/lib/types/client.ts
@@ -1,0 +1,55 @@
+import type { I18nextHandler, I18nContext, I18nOptions } from '../../index';
+
+export interface I18nextClient {
+	i18n: I18nextHandler;
+
+	/**
+	 * The method to be overriden by the developer.
+	 * Note: In the event that fetchLanguage is not defined or returns
+	 * null / undefined, the defaulting from {@link I18nextBaseImplementation.fetchLanguage} will be used.
+	 * @since 1.0.0
+	 * @return A string for the desired language or null for no match.
+	 * @see {@link I18nextBaseImplementation.fetchLanguage}
+	 * @example
+	 * ```typescript
+	 * // Always use the same language (no per-guild configuration):
+	 * client.fetchLanguage = () => 'en-US';
+	 * ```
+	 * @example
+	 * ```typescript
+	 * // Retrieving the language from an SQL database:
+	 * client.fetchLanguage = async (context) => {
+	 *   const guild = await driver.getOne('SELECT language FROM public.guild WHERE id = $1', [context.guild.id]);
+	 *   return guild?.language ?? 'en-US';
+	 * };
+	 * ```
+	 * @example
+	 * ```typescript
+	 * // Retrieving the language from an ORM:
+	 * client.fetchLanguage = async (context) => {
+	 *   const guild = await driver.getRepository(GuildEntity).findOne({ id: context.guild.id });
+	 *   return guild?.language ?? 'en-US';
+	 * };
+	 * ```
+	 * @example
+	 * ```typescript
+	 * // Retrieving the language on a per channel basis, e.g. per user or guild channel (ORM example but same principles apply):
+	 * client.fetchLanguage = async (context) => {
+	 *   const channel = await driver.getRepository(ChannelEntity).findOne({ id: context.channel.id });
+	 *   return channel?.language ?? 'en-US';
+	 * };
+	 * ```
+	 */
+	fetchLanguage: (context: I18nContext) => Promise<string | null> | string | null;
+}
+
+export interface I18nextClientOptions {
+	i18n?: I18nOptions;
+
+	/**
+	 * Hook that returns the name of a language. Should correspond to {@link I18nextClient.fetchLanguage}.
+	 * @since 1.0.0
+	 * @default () => {@link I18nOptions.defaultName}
+	 */
+	fetchLanguage?: (context: I18nContext) => Promise<string | null> | string | null;
+}

--- a/packages/i18next/src/lib/types/context.ts
+++ b/packages/i18next/src/lib/types/context.ts
@@ -2,22 +2,28 @@
  * Context for the guild, used in fetchLanguage functions.
  * Should be an extension of your framework's Guild object, or the corresponding I18n extension.
  */
-export interface I18nGuildContext {}
+export interface I18nGuildContext {
+	/**
+	 * The preferred language for the guild context. Used as part of the default chain for {@link I18nextBaseImplementation.fetchLanguage}.
+	 * @since 1.0.0
+	 */
+	preferredLocale: string;
+}
 
 /**
- * Context for the channel, used in fetchLanguage functions.
+ * Context for the channel, used in {@link I18nextBaseImplementation.fetchLanguage} functions.
  * Should be an extension of your framework's Channel object, or the corresponding I18n extension.
  */
 export interface I18nChannelContext {}
 
 /**
- * Context for the user sending a message, used in fetchLanguage functions.
+ * Context for the user sending a message, used in {@link I18nextBaseImplementation.fetchLanguage} functions.
  * Should be an extension of your framework's User object, or the corresponding I18n extension.
  */
 export interface I18nAuthorContext {}
 
 /**
- * Context for fetchLanguage functions.
+ * Context for {@link I18nextBaseImplementation.fetchLanguage} functions.
  * This context enables implementation of per-guild, per-channel, and per-user localisation.
  */
 export interface I18nContext {

--- a/packages/i18next/src/lib/types/implementations.ts
+++ b/packages/i18next/src/lib/types/implementations.ts
@@ -1,0 +1,53 @@
+import type { TFunction } from 'i18next';
+
+export interface I18nextBaseImplementation {
+	/**
+	 * @since 1.0.0
+	 * @default {@link I18nextClient.fetchLanguage} -> {@link I18nextGuildContext.preferredLocale} -> {@link I18nOptions.defaultName} -> 'en-US'
+	 * @see {@link I18nextClient.fetchLanguage}
+	 */
+	fetchLanguage(): Promise<string>;
+
+	/**
+	 * @since 1.0.0
+	 * @return An i18next [TFunction](https://www.i18next.com/overview/api#t).
+	 */
+	fetchT(): Promise<TFunction>;
+
+	/**
+	 * Function that resolves a language key from the store.
+	 * @since 1.0.0
+	 * @return A string, which is the translated result of the key, with templated values.
+	 */
+	resolveKey(key: string, ...values: readonly any[]): Promise<string>;
+}
+
+export interface I18nextGuildImplementation extends I18nextBaseImplementation {}
+
+export interface I18nextChannelImplementation extends I18nextBaseImplementation {
+	/**
+	 * Function that sends a message for the channel with the translated key and values.
+	 * Functionally equivalent to piping {@link I18nextBaseImplementation.resolveKey} through the channel's message send method.
+	 * @since 1.0.0
+	 * @return The message that was sent.
+	 */
+	sendTranslated(key: string, values?: readonly unknown[], options?: unknown): Promise<I18nextMessageImplementation>;
+}
+
+export interface I18nextMessageImplementation extends I18nextBaseImplementation {
+	/**
+	 * Function that sends a response message for the context channel with the translated key and values.
+	 * Functionally equivalent to piping {@link I18nextBaseImplementation.resolveKey} through the message's reply method.
+	 * @since 1.0.0
+	 * @return The message that was sent.
+	 */
+	replyTranslated(key: string, values?: readonly unknown[], options?: unknown): Promise<I18nextMessageImplementation>;
+
+	/**
+	 * Function that edits a message with the translated key and values.
+	 * Functionally equivalent to piping {@link I18nextBaseImplementation.resolveKey} through the message's edit method.
+	 * @since 1.0.0
+	 * @return The message that was edited.
+	 */
+	editTranslated(key: string, values?: readonly unknown[], options?: unknown): Promise<I18nextMessageImplementation>;
+}

--- a/packages/i18next/src/lib/types/index.ts
+++ b/packages/i18next/src/lib/types/index.ts
@@ -1,0 +1,4 @@
+export * from './client';
+export * from './context';
+export * from './options';
+export * from './implementations';

--- a/packages/i18next/src/register-discordjs.ts
+++ b/packages/i18next/src/register-discordjs.ts
@@ -1,35 +1,24 @@
 import './register';
 export * from './register';
-import type { TFunction } from 'i18next';
-import type { I18nextHandler, I18nOptions, I18nContext } from './index';
-import { Message, MessageAdditions, MessageOptions, SplitOptions, Structures, Channel, Guild, User, Client } from 'discord.js';
+import {
+	I18nextClient,
+	I18nextClientOptions,
+	I18nextImplemented,
+	I18nextGuildImplementation,
+	I18nextChannelImplementation,
+	I18nextMessageImplementation
+} from './index';
+import { Message, MessageAdditions, MessageOptions, SplitOptions, Structures, Channel, Guild, User } from 'discord.js';
 
 declare module './index' {
 	export interface I18nGuildContext extends Guild {}
 	export interface I18nChannelContext extends Channel {}
-	export interface I18nAuthorContext extends Channel {}
+	export interface I18nAuthorContext extends User {}
 }
 
-async function fetchLanguage(client: Client, guild?: Guild | null, channel?: Channel | null, author?: User | null): Promise<string> {
-	const lang = await client.fetchLanguage({
-		guild,
-		channel,
-		author
-	} as I18nContext);
-	return lang ?? guild?.preferredLocale ?? client.i18n?.options?.defaultName ?? 'en-US';
-}
-
-class I18nextMessage extends Structures.get('Message') {
+class I18nextMessage extends I18nextImplemented(Structures.get('Message')) implements I18nextMessageImplementation {
 	public async fetchLanguage(): Promise<string> {
-		return fetchLanguage(this.client, this.guild, this.channel, this.author);
-	}
-
-	public async fetchT(): Promise<TFunction> {
-		return this.client.i18n.fetchT(await this.fetchLanguage());
-	}
-
-	public async resolveKey(key: string, ...values: readonly any[]): Promise<string> {
-		return this.client.i18n.fetchLocale(await this.fetchLanguage(), key, ...values);
+		return this._fetchLanguage(this.guild, this.channel, this.author);
 	}
 
 	public replyTranslated(
@@ -75,17 +64,9 @@ class I18nextMessage extends Structures.get('Message') {
 	}
 }
 
-class I18nextTextChannel extends Structures.get('TextChannel') {
+class I18nextTextChannel extends I18nextImplemented(Structures.get('TextChannel')) implements I18nextChannelImplementation {
 	public async fetchLanguage(): Promise<string> {
-		return fetchLanguage(this.client, this.guild, this, undefined);
-	}
-
-	public async fetchT(): Promise<TFunction> {
-		return this.client.i18n.fetchT(await this.fetchLanguage());
-	}
-
-	public async resolveKey(key: string, ...values: readonly any[]): Promise<string> {
-		return this.client.i18n.fetchLocale(await this.fetchLanguage(), key, ...values);
+		return this._fetchLanguage(this.guild, this, undefined);
 	}
 
 	public sendTranslated(
@@ -110,17 +91,9 @@ class I18nextTextChannel extends Structures.get('TextChannel') {
 	}
 }
 
-class I18nextDMChannel extends Structures.get('DMChannel') {
+class I18nextDMChannel extends I18nextImplemented(Structures.get('DMChannel')) implements I18nextChannelImplementation {
 	public async fetchLanguage(): Promise<string> {
-		return fetchLanguage(this.client, undefined, this, undefined);
-	}
-
-	public async fetchT(): Promise<TFunction> {
-		return this.client.i18n.fetchT(await this.fetchLanguage());
-	}
-
-	public async resolveKey(key: string, ...values: readonly any[]): Promise<string> {
-		return this.client.i18n.fetchLocale(await this.fetchLanguage(), key, ...values);
+		return this._fetchLanguage(undefined, this, undefined);
 	}
 
 	public sendTranslated(
@@ -145,17 +118,9 @@ class I18nextDMChannel extends Structures.get('DMChannel') {
 	}
 }
 
-class I18nextNewsChannel extends Structures.get('NewsChannel') {
+class I18nextNewsChannel extends I18nextImplemented(Structures.get('NewsChannel')) implements I18nextChannelImplementation {
 	public async fetchLanguage(): Promise<string> {
-		return fetchLanguage(this.client, this.guild, this, undefined);
-	}
-
-	public async fetchT(): Promise<TFunction> {
-		return this.client.i18n.fetchT(await this.fetchLanguage());
-	}
-
-	public async resolveKey(key: string, ...values: readonly any[]): Promise<string> {
-		return this.client.i18n.fetchLocale(await this.fetchLanguage(), key, ...values);
+		return this._fetchLanguage(this.guild, this, undefined);
 	}
 
 	public sendTranslated(
@@ -180,17 +145,9 @@ class I18nextNewsChannel extends Structures.get('NewsChannel') {
 	}
 }
 
-class I18nextGuild extends Structures.get('Guild') {
+class I18nextGuild extends I18nextImplemented(Structures.get('Guild')) implements I18nextGuildImplementation {
 	public async fetchLanguage(): Promise<string> {
-		return fetchLanguage(this.client, this, undefined, undefined);
-	}
-
-	public async fetchT(): Promise<TFunction> {
-		return this.client.i18n.fetchT(await this.fetchLanguage());
-	}
-
-	public async resolveKey(key: string, ...values: readonly any[]): Promise<string> {
-		return this.client.i18n.fetchLocale(await this.fetchLanguage(), key, ...values);
+		return this._fetchLanguage(this, undefined, undefined);
 	}
 }
 
@@ -201,186 +158,61 @@ Structures.extend('NewsChannel', () => I18nextNewsChannel);
 Structures.extend('Guild', () => I18nextGuild);
 
 declare module 'discord.js' {
-	export interface Message {
+	export interface Message extends I18nextMessageImplementation {
 		/**
-		 * Accessor for {@link I18nextPlugin#fetchLanguage} that implements an order of preference for locales.
-		 * @since 1.0.0
-		 * @return In preference order, {@link I18nextPlugin#fetchLanguage} -> the guild's preferredLocale -> {@link I18nextOptions#defaultName} -> 'en-US'.
-		 */
-		fetchLanguage(): Promise<string>;
-
-		/**
-		 * Function that gets a TFunction (translator function) from i18next.
-		 * @since 1.0.0
-		 * @return An i18next TFunction.
-		 */
-		fetchT(): Promise<TFunction>;
-
-		/**
-		 * Function that resolves a language key from the store.
-		 * @since 1.0.0
-		 * @return A string, which is the translated result of the key, with templated values.
-		 */
-		resolveKey(key: string, ...values: readonly any[]): Promise<string>;
-
-		/**
-		 * Function that sends a response message for the context channel with the translated key and values.
-		 * Functionally equivalent to piping resolveKey through Message#reply.
-		 * @since 1.0.0
-		 * @return The message object that was sent.
+		 * @see {@link I18nextMessageImplementation.replyTranslated}
 		 */
 		replyTranslated(
 			key: string,
 			values?: readonly unknown[],
 			options?: MessageOptions | (MessageOptions & { split?: false }) | MessageAdditions
-		): Promise<Message>;
-		replyTranslated(key: string, values?: readonly unknown[], options?: MessageOptions & { split: true | SplitOptions }): Promise<Message[]>;
-		replyTranslated(key: string, options?: MessageOptions | (MessageOptions & { split?: false }) | MessageAdditions): Promise<Message>;
-		replyTranslated(key: string, options?: MessageOptions & { split: true | SplitOptions }): Promise<Message[]>;
+		): Promise<I18nextMessageImplementation>;
+		replyTranslated(
+			key: string,
+			values?: readonly unknown[],
+			options?: MessageOptions & { split: true | SplitOptions }
+		): Promise<I18nextMessageImplementation[]>;
+		replyTranslated(
+			key: string,
+			options?: MessageOptions | (MessageOptions & { split?: false }) | MessageAdditions
+		): Promise<I18nextMessageImplementation>;
+		replyTranslated(key: string, options?: MessageOptions & { split: true | SplitOptions }): Promise<I18nextMessageImplementation[]>;
 		replyTranslated(
 			key: string,
 			valuesOrOptions?: readonly unknown[] | MessageOptions | MessageAdditions,
 			rawOptions?: MessageOptions
-		): Promise<Message | Message[]>;
-
-		/**
-		 * Function that edits a message with the translated key and values.
-		 * Functionally equivalent to piping resolveKey through Message#edit.
-		 * @since 1.0.0
-		 * @return The message object that was edited.
-		 */
-		editTranslated(
-			key: string,
-			values?: readonly unknown[],
-			options?: MessageOptions | (MessageOptions & { split?: false }) | MessageAdditions
-		): Promise<Message>;
-		editTranslated(key: string, values?: readonly unknown[], options?: MessageOptions & { split: true | SplitOptions }): Promise<Message[]>;
-		editTranslated(key: string, options?: MessageOptions | (MessageOptions & { split?: false }) | MessageAdditions): Promise<Message>;
-		editTranslated(key: string, options?: MessageOptions & { split: true | SplitOptions }): Promise<Message[]>;
-		editTranslated(
-			key: string,
-			valuesOrOptions?: readonly unknown[] | MessageOptions | MessageAdditions,
-			rawOptions?: MessageOptions
-		): Promise<Message | Message[]>;
+		): Promise<I18nextMessageImplementation | I18nextMessageImplementation[]>;
 	}
 
-	export interface Channel {
+	export interface Channel extends I18nextChannelImplementation {
 		/**
-		 * Accessor for {@link I18nextPlugin#fetchLanguage} that implements an order of preference for locales.
-		 * @since 1.0.0
-		 * @return In preference order, {@link I18nextPlugin#fetchLanguage} -> the guild's preferredLocale -> {@link I18nextOptions#defaultName} -> 'en-US'.
-		 */
-		fetchLanguage(): Promise<string>;
-
-		/**
-		 * Function that gets a TFunction (translator function) from i18next.
-		 * @since 1.0.0
-		 * @return An i18next TFunction.
-		 */
-		fetchT(): Promise<TFunction>;
-
-		/**
-		 * Function that resolves a language key from the store.
-		 * @since 1.0.0
-		 * @return A string, which is the translated result of the key, with templated values.
-		 */
-		resolveKey(key: string, ...values: readonly any[]): Promise<string>;
-
-		/**
-		 * Function that sends a message for the channel with the translated key and values.
-		 * Functionally equivalent to piping resolveKey through Channel#send.
-		 * @since 1.0.0
-		 * @return The message object that was sent.
+		 * @see {@link I18nextChannelImplementation.sendTranslated}
 		 */
 		sendTranslated(
 			key: string,
 			values?: readonly unknown[],
 			options?: MessageOptions | (MessageOptions & { split?: false }) | MessageAdditions
-		): Promise<Message>;
-		sendTranslated(key: string, values?: readonly unknown[], options?: MessageOptions & { split: true | SplitOptions }): Promise<Message[]>;
-		sendTranslated(key: string, options?: MessageOptions | (MessageOptions & { split?: false }) | MessageAdditions): Promise<Message>;
-		sendTranslated(key: string, options?: MessageOptions & { split: true | SplitOptions }): Promise<Message[]>;
+		): Promise<I18nextMessageImplementation>;
+		sendTranslated(
+			key: string,
+			values?: readonly unknown[],
+			options?: MessageOptions & { split: true | SplitOptions }
+		): Promise<I18nextMessageImplementation[]>;
+		sendTranslated(
+			key: string,
+			options?: MessageOptions | (MessageOptions & { split?: false }) | MessageAdditions
+		): Promise<I18nextMessageImplementation>;
+		sendTranslated(key: string, options?: MessageOptions & { split: true | SplitOptions }): Promise<I18nextMessageImplementation[]>;
 		sendTranslated(
 			key: string,
 			valuesOrOptions?: readonly unknown[] | MessageOptions | MessageAdditions,
 			rawOptions?: MessageOptions
-		): Promise<Message | Message[]>;
+		): Promise<I18nextMessageImplementation | I18nextMessageImplementation[]>;
 	}
 
-	export interface Guild {
-		/**
-		 * Accessor for {@link I18nextPlugin#fetchLanguage} that implements an order of preference for locales.
-		 * @since 1.0.0
-		 * @return In preference order, {@link I18nextPlugin#fetchLanguage} -> the guild's preferredLocale -> {@link I18nextOptions#defaultName} -> 'en-US'.
-		 */
-		fetchLanguage(): Promise<string>;
+	export interface Guild extends I18nextGuildImplementation {}
 
-		/**
-		 * Function that gets a TFunction (translator function) from i18next.
-		 * @since 1.0.0
-		 * @return An i18next TFunction.
-		 */
-		fetchT(): Promise<TFunction>;
+	export interface Client extends I18nextClient {}
 
-		/**
-		 * Function that resolves a language key from the store.
-		 * @since 1.0.0
-		 * @return A string, which is the translated result of the key, with templated values.
-		 */
-		resolveKey(key: string, ...values: readonly any[]): Promise<string>;
-	}
-
-	export interface Client {
-		/**
-		 * See: {@link I18nextHandler}
-		 * @since 1.0.0
-		 */
-		i18n: I18nextHandler;
-
-		/**
-		 * The method to be overriden by the developer.
-		 * Note: In the event that fetchLanguage is not defined or returns null or undefined
-		 * the order of defaulting will be as follows:
-		 * client.fetchLanguage -> message.guild.preferredLocale -> this.client.options.i18n.defaultName -> 'en-US'
-		 * @since 1.0.0
-		 * @return A string for the desired language or null for no match.
-		 * @example
-		 * ```typescript
-		 * // Always use the same language (no per-guild configuration):
-		 * client.fetchLanguage = () => 'en-US';
-		 * ```
-		 * @example
-		 * ```typescript
-		 * // Retrieving the prefix from an SQL database:
-		 * client.fetchLanguage = async (message) => {
-		 *   const guild = await driver.getOne('SELECT language FROM public.guild WHERE id = $1', [message.guild.id]);
-		 *   return guild?.language ?? 'en-US';
-		 * };
-		 * ```
-		 * @example
-		 * ```typescript
-		 * // Retrieving the language from an ORM:
-		 * client.fetchLanguage = async (message) => {
-		 *   const guild = await driver.getRepository(GuildEntity).findOne({ id: message.guild.id });
-		 *   return guild?.language ?? 'en-US';
-		 * };
-		 * ```
-		 */
-		fetchLanguage: (context: I18nContext) => Promise<string | null> | string | null;
-	}
-
-	export interface ClientOptions {
-		/**
-		 * See: {@link I18nOptions}
-		 * @since 1.0.0
-		 */
-		i18n?: I18nOptions;
-
-		/**
-		 * Hook that returns the name of a language, or {@link I18nOptions#defaultName} by default.
-		 * @since 1.0.0
-		 * @default () => client.options.defaultLanguage
-		 */
-		fetchLanguage?: (context: I18nContext) => Promise<string | null> | string | null;
-	}
+	export interface ClientOptions extends I18nextClientOptions {}
 }

--- a/packages/i18next/src/register.ts
+++ b/packages/i18next/src/register.ts
@@ -1,8 +1,8 @@
-import { Plugin, preGenericsInitialization, preLogin, SapphireClient, SapphireClientOptions } from '@sapphire/framework';
-import { I18nextHandler, I18nOptions, I18nContext } from './index';
+import { Plugin, preGenericsInitialization, preLogin, SapphireClient } from '@sapphire/framework';
+import { I18nextHandler, I18nextClient, I18nextClientOptions } from './index';
 
 export class I18nextPlugin extends Plugin {
-	public static [preGenericsInitialization](this: SapphireClient, options: SapphireClientOptions): void {
+	public static [preGenericsInitialization](this: I18nextClient, options: I18nextClientOptions): void {
 		this.i18n = new I18nextHandler(options.i18n);
 
 		this.fetchLanguage = options.fetchLanguage ?? (() => null);
@@ -14,59 +14,9 @@ export class I18nextPlugin extends Plugin {
 }
 
 declare module '@sapphire/framework' {
-	export interface SapphireClient {
-		i18n: I18nextHandler;
+	export interface SapphireClient extends I18nextClient {}
 
-		/**
-		 * The method to be overriden by the developer.
-		 * Note: In the event that fetchLanguage is not defined or returns null or undefined
-		 * the order of defaulting will be as follows:
-		 * client.fetchLanguage -> guild.preferredLocale -> client.options.i18n.defaultName -> 'en-US'
-		 * @since 1.0.0
-		 * @return A string for the desired language or null for no match.
-		 * @example
-		 * ```typescript
-		 * // Always use the same language (no per-guild configuration):
-		 * client.fetchLanguage = () => 'en-US';
-		 * ```
-		 * @example
-		 * ```typescript
-		 * // Retrieving the language from an SQL database:
-		 * client.fetchLanguage = async (context) => {
-		 *   const guild = await driver.getOne('SELECT language FROM public.guild WHERE id = $1', [context.guild.id]);
-		 *   return guild?.language ?? 'en-US';
-		 * };
-		 * ```
-		 * @example
-		 * ```typescript
-		 * // Retrieving the language from an ORM:
-		 * client.fetchLanguage = async (context) => {
-		 *   const guild = await driver.getRepository(GuildEntity).findOne({ id: context.guild.id });
-		 *   return guild?.language ?? 'en-US';
-		 * };
-		 * ```
-		 * @example
-		 * ```typescript
-		 * // Retrieving the language on a per channel basis, e.g. per user or guild channel (ORM example but same principles apply):
-		 * client.fetchLanguage = async (context) => {
-		 *   const channel = await driver.getRepository(ChannelEntity).findOne({ id: context.channel.id });
-		 *   return channel?.language ?? 'en-US';
-		 * };
-		 * ```
-		 */
-		fetchLanguage: (context: I18nContext) => Promise<string | null> | string | null;
-	}
-
-	export interface SapphireClientOptions {
-		i18n?: I18nOptions;
-
-		/**
-		 * Hook that returns the name of a language, or {@link I18nOptions#defaultName} by default.
-		 * @since 1.0.0
-		 * @default () => client.options.defaultLanguage
-		 */
-		fetchLanguage?: (context: I18nContext) => Promise<string | null> | string | null;
-	}
+	export interface SapphireClientOptions extends I18nextClientOptions {}
 }
 
 SapphireClient.plugins.registerPostInitializationHook(I18nextPlugin[preGenericsInitialization], 'I18next-PreGenericsInitialization');


### PR DESCRIPTION
This does not change any functionality, however, documentation has been greatly improved, register
interfaces have been standardized, and instead of numerous re-implementations, mixins and factory
functions are now used. This makes augmenting any part of the plugin and implementing it with
various libraries in an agnostic way much easier and much more accessible, especially with the new
proper documentation.