### PR TITLE
feat: create plugin-prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@
 [![npm](https://img.shields.io/npm/v/@sapphire/plugin-api?color=crimson&logo=npm&style=flat-square&label=@sapphire/plugin-api)](https://www.npmjs.com/package/@sapphire/plugin-api)
 [![npm](https://img.shields.io/npm/v/@sapphire/plugin-logger?color=crimson&logo=npm&style=flat-square&label=@sapphire/plugin-logger)](https://www.npmjs.com/package/@sapphire/plugin-logger)
 [![npm](https://img.shields.io/npm/v/@sapphire/plugin-i18next?color=crimson&logo=npm&style=flat-square&label=@sapphire/plugin-i18next)](https://www.npmjs.com/package/@sapphire/plugin-i18next)
+[![npm](https://img.shields.io/npm/v/@sapphire/plugin-prompt?color=crimson&logo=npm&style=flat-square&label=@sapphire/plugin-prompt)](https://www.npmjs.com/package/@sapphire/plugin-prompt)
 
 </div>
 

--- a/packages/prompt/README.md
+++ b/packages/prompt/README.md
@@ -11,7 +11,7 @@
 [![Language grade: JavaScript](https://img.shields.io/lgtm/grade/javascript/g/sapphire-project/plugins.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/sapphire-project/plugins/context:javascript)
 [![Coverage Status](https://coveralls.io/repos/github/sapphire-project/plugins/badge.svg?branch=main)](https://coveralls.io/github/sapphire-project/plugins?branch=main)
 [![npm bundle size](https://img.shields.io/bundlephobia/min/@sapphire/plugin-prompt?logo=webpack&style=flat-square)](https://bundlephobia.com/result?p=@sapphire/plugin-prompt)
-[![npm](https://img.shields.io/npm/v/@sapphire/plugin-i18n?color=crimson&logo=npm&style=flat-square)](https://www.npmjs.com/package/@sapphire/plugin-prompt)
+[![npm](https://img.shields.io/npm/v/@sapphire/plugin-prompt?color=crimson&logo=npm&style=flat-square)](https://www.npmjs.com/package/@sapphire/plugin-prompt)
 [![Depfu](https://badges.depfu.com/badges/11bbf7392987e6fd51fc6559e1d42dfc/count.svg)](https://depfu.com/github/sapphire-project/plugins?project_id=15201)
 
 </div>

--- a/packages/prompt/README.md
+++ b/packages/prompt/README.md
@@ -2,9 +2,9 @@
 
 ![Sapphire Logo](https://cdn.skyra.pw/gh-assets/sapphire.png)
 
-# @sapphire/plugin-i18next
+# @sapphire/plugin-prompt
 
-**Plugin for <a href="https://github.com/sapphire-project/framework">@sapphire/framework</a> to support i18next based internationalization.**
+**Plugin for <a href="https://github.com/sapphire-project/framework">@sapphire/framework</a> to add prompt messages.**
 
 [![GitHub](https://img.shields.io/github/license/sapphire-project/plugins)](https://github.com/sapphire-project/plugins/blob/main/LICENSE.md)
 [![Total alerts](https://img.shields.io/lgtm/alerts/g/sapphire-project/plugins.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/sapphire-project/plugins/alerts/)
@@ -18,21 +18,18 @@
 
 ## Description
 
-An implementation of i18next's [filesystem backend] for Sapphire. It allows you to use a JSON-based `languages` directory to add internationalization for your bot using `SapphireClient`'s `fetchLanguage` hook and a custom message extension, adding features such as `sendTranslated` and `resolveKey`.
-
-[filesystem backend]: https://github.com/i18next/i18next-fs-backend
+Simple plugin to extend Channel & Messages with a prompt.
 
 ## Features
 
 -   Fully ready for TypeScript!
 -   Includes ESM ready entrypoint
--   Framework agnostic
 -   Includes convenience register for discord.js
 
 ## Installation
 
 ```sh
-yarn add -D @sapphire/plugin-i18next
+yarn add -D @sapphire/plugin-prompt
 ```
 
 ---
@@ -40,22 +37,22 @@ yarn add -D @sapphire/plugin-i18next
 ## Usage
 
 ```typescript
-import '@sapphire/plugin-i18next/register';
+import '@sapphire/plugin-prompt/register';
 ```
 
 And for discord.js:
 
 ```typescript
-import '@sapphire/plugin-i18next/register-discordjs';
+import '@sapphire/plugin-prompt/register-discordjs';
 ```
 
-It is to be noted that unless you are using discord.js, which has the convenience register to extend the client, guild, channel and message methods for you, you will have to implement your own extensions.
+It is to be noted that unless you are using discord.js, which has the convenience register to extend the channel and message methods for you, you will have to implement your own extensions.
 
 This is currently undocumented and not covered by guides, but will be in the future. For now, you may follow the structure of `register-discordjs.ts` if this is the case for you.
 
-## Sapphire i18next Documentation
+## Sapphire prompt Documentation
 
-For the full @sapphire/plugin-i18next documentation please refer to the TypeDoc generated [documentation](https://sapphire-project.github.io/plugins/modules/_sapphire_plugin_i18next.html).
+For the full @sapphire/plugin-prompt documentation please refer to the TypeDoc generated [documentation](https://sapphire-project.github.io/plugins/modules/_sapphire_plugin_prompt.html).
 
 ## Buy us some doughnuts
 
@@ -79,16 +76,16 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
 <!-- markdownlint-disable -->
 <table>
   <tr>
-    <td align="center"><a href="https://favware.tech/"><img src="https://avatars3.githubusercontent.com/u/4019718?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Jeroen Claassens</b></sub></a><br /><a href="https://github.com/sapphire-project/plugins/commits?author=Favna" title="Code">💻</a> <a href="#infra-Favna" title="Infrastructure (Hosting, Build-Tools, etc)">🚇</a> <a href="#projectManagement-Favna" title="Project Management">📆</a></td>
-    <td align="center"><a href="https://quantumlytangled.com"><img src="https://avatars1.githubusercontent.com/u/7919610?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Nejc Drobnic</b></sub></a><br /><a href="https://github.com/sapphire-project/plugins/commits?author=QuantumlyTangled" title="Code">💻</a> <a href="https://github.com/sapphire-project/plugins/commits?author=QuantumlyTangled" title="Documentation">📖</a></td>
-    <td align="center"><a href="https://github.com/kyranet"><img src="https://avatars0.githubusercontent.com/u/24852502?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Antonio Román</b></sub></a><br /><a href="https://github.com/sapphire-project/plugins/commits?author=kyranet" title="Code">💻</a></td>
-    <td align="center"><a href="https://github.com/vladfrangu"><img src="https://avatars3.githubusercontent.com/u/17960496?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Vlad Frangu</b></sub></a><br /><a href="https://github.com/sapphire-project/plugins/pulls?q=is%3Apr+reviewed-by%3Avladfrangu" title="Reviewed Pull Requests">👀</a></td>
-    <td align="center"><a href="https://github.com/apps/depfu"><img src="https://avatars3.githubusercontent.com/in/715?v=4?s=100" width="100px;" alt=""/><br /><sub><b>depfu[bot]</b></sub></a><br /><a href="#maintenance-depfu[bot]" title="Maintenance">🚧</a></td>
-    <td align="center"><a href="https://github.com/apps/dependabot"><img src="https://avatars0.githubusercontent.com/in/29110?v=4?s=100" width="100px;" alt=""/><br /><sub><b>dependabot[bot]</b></sub></a><br /><a href="#maintenance-dependabot[bot]" title="Maintenance">🚧</a></td>
-    <td align="center"><a href="https://github.com/apps/allcontributors"><img src="https://avatars0.githubusercontent.com/in/23186?v=4?s=100" width="100px;" alt=""/><br /><sub><b>allcontributors[bot]</b></sub></a><br /><a href="https://github.com/sapphire-project/plugins/commits?author=allcontributors[bot]" title="Documentation">📖</a></td>
+    <td align="center"><a href="https://favware.tech/"><img src="https://avatars3.githubusercontent.com/u/4019718?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Jeroen Claassens</b></sub></a><br /><a href="https://github.com/sapphire-project/plugins/commits?author=Favna" title="Code">�</a> <a href="#infra-Favna" title="Infrastructure (Hosting, Build-Tools, etc)">�</a> <a href="#projectManagement-Favna" title="Project Management">�</a></td>
+    <td align="center"><a href="https://quantumlytangled.com"><img src="https://avatars1.githubusercontent.com/u/7919610?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Nejc Drobnic</b></sub></a><br /><a href="https://github.com/sapphire-project/plugins/commits?author=QuantumlyTangled" title="Code">�</a> <a href="https://github.com/sapphire-project/plugins/commits?author=QuantumlyTangled" title="Documentation">�</a></td>
+    <td align="center"><a href="https://github.com/kyranet"><img src="https://avatars0.githubusercontent.com/u/24852502?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Antonio Román</b></sub></a><br /><a href="https://github.com/sapphire-project/plugins/commits?author=kyranet" title="Code">�</a></td>
+    <td align="center"><a href="https://github.com/vladfrangu"><img src="https://avatars3.githubusercontent.com/u/17960496?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Vlad Frangu</b></sub></a><br /><a href="https://github.com/sapphire-project/plugins/pulls?q=is%3Apr+reviewed-by%3Avladfrangu" title="Reviewed Pull Requests">�</a></td>
+    <td align="center"><a href="https://github.com/apps/depfu"><img src="https://avatars3.githubusercontent.com/in/715?v=4?s=100" width="100px;" alt=""/><br /><sub><b>depfu[bot]</b></sub></a><br /><a href="#maintenance-depfu[bot]" title="Maintenance">�</a></td>
+    <td align="center"><a href="https://github.com/apps/dependabot"><img src="https://avatars0.githubusercontent.com/in/29110?v=4?s=100" width="100px;" alt=""/><br /><sub><b>dependabot[bot]</b></sub></a><br /><a href="#maintenance-dependabot[bot]" title="Maintenance">�</a></td>
+    <td align="center"><a href="https://github.com/apps/allcontributors"><img src="https://avatars0.githubusercontent.com/in/23186?v=4?s=100" width="100px;" alt=""/><br /><sub><b>allcontributors[bot]</b></sub></a><br /><a href="https://github.com/sapphire-project/plugins/commits?author=allcontributors[bot]" title="Documentation">�</a></td>
   </tr>
   <tr>
-    <td align="center"><a href="https://github.com/Nytelife26"><img src="https://avatars1.githubusercontent.com/u/22531310?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Tyler J Russell</b></sub></a><br /><a href="https://github.com/sapphire-project/plugins/commits?author=Nytelife26" title="Code">💻</a></td>
+    <td align="center"><a href="https://github.com/Nytelife26"><img src="https://avatars1.githubusercontent.com/u/22531310?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Tyler J Russell</b></sub></a><br /><a href="https://github.com/sapphire-project/plugins/commits?author=Nytelife26" title="Code">�</a></td>
   </tr>
 </table>
 

--- a/packages/prompt/README.md
+++ b/packages/prompt/README.md
@@ -18,7 +18,7 @@
 
 ## Description
 
-Simple plugin to extend Channel & Messages with a prompt.
+There are various times that would want your bot to prompt the user of a command for something, such as asking them confirmation for certain actions. This is where @sapphire/plugin-prompt comes in as the perfect plugin to use. Using this plugin you can easily send prompt messages and handle the responses from users.
 
 ## Features
 

--- a/packages/prompt/README.md
+++ b/packages/prompt/README.md
@@ -10,8 +10,8 @@
 [![Total alerts](https://img.shields.io/lgtm/alerts/g/sapphire-project/plugins.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/sapphire-project/plugins/alerts/)
 [![Language grade: JavaScript](https://img.shields.io/lgtm/grade/javascript/g/sapphire-project/plugins.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/sapphire-project/plugins/context:javascript)
 [![Coverage Status](https://coveralls.io/repos/github/sapphire-project/plugins/badge.svg?branch=main)](https://coveralls.io/github/sapphire-project/plugins?branch=main)
-[![npm bundle size](https://img.shields.io/bundlephobia/min/@sapphire/plugin-in17n?logo=webpack&style=flat-square)](https://bundlephobia.com/result?p=@sapphire/plugin-in17n)
-[![npm](https://img.shields.io/npm/v/@sapphire/plugin-in17n?color=crimson&logo=npm&style=flat-square)](https://www.npmjs.com/package/@sapphire/plugin-in17n)
+[![npm bundle size](https://img.shields.io/bundlephobia/min/@sapphire/plugin-prompt?logo=webpack&style=flat-square)](https://bundlephobia.com/result?p=@sapphire/plugin-prompt)
+[![npm](https://img.shields.io/npm/v/@sapphire/plugin-i18n?color=crimson&logo=npm&style=flat-square)](https://www.npmjs.com/package/@sapphire/plugin-prompt)
 [![Depfu](https://badges.depfu.com/badges/11bbf7392987e6fd51fc6559e1d42dfc/count.svg)](https://depfu.com/github/sapphire-project/plugins?project_id=15201)
 
 </div>

--- a/packages/prompt/README.md
+++ b/packages/prompt/README.md
@@ -1,0 +1,100 @@
+<div align="center">
+
+![Sapphire Logo](https://cdn.skyra.pw/gh-assets/sapphire.png)
+
+# @sapphire/plugin-i18next
+
+**Plugin for <a href="https://github.com/sapphire-project/framework">@sapphire/framework</a> to support i18next based internationalization.**
+
+[![GitHub](https://img.shields.io/github/license/sapphire-project/plugins)](https://github.com/sapphire-project/plugins/blob/main/LICENSE.md)
+[![Total alerts](https://img.shields.io/lgtm/alerts/g/sapphire-project/plugins.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/sapphire-project/plugins/alerts/)
+[![Language grade: JavaScript](https://img.shields.io/lgtm/grade/javascript/g/sapphire-project/plugins.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/sapphire-project/plugins/context:javascript)
+[![Coverage Status](https://coveralls.io/repos/github/sapphire-project/plugins/badge.svg?branch=main)](https://coveralls.io/github/sapphire-project/plugins?branch=main)
+[![npm bundle size](https://img.shields.io/bundlephobia/min/@sapphire/plugin-in17n?logo=webpack&style=flat-square)](https://bundlephobia.com/result?p=@sapphire/plugin-in17n)
+[![npm](https://img.shields.io/npm/v/@sapphire/plugin-in17n?color=crimson&logo=npm&style=flat-square)](https://www.npmjs.com/package/@sapphire/plugin-in17n)
+[![Depfu](https://badges.depfu.com/badges/11bbf7392987e6fd51fc6559e1d42dfc/count.svg)](https://depfu.com/github/sapphire-project/plugins?project_id=15201)
+
+</div>
+
+## Description
+
+An implementation of i18next's [filesystem backend] for Sapphire. It allows you to use a JSON-based `languages` directory to add internationalization for your bot using `SapphireClient`'s `fetchLanguage` hook and a custom message extension, adding features such as `sendTranslated` and `resolveKey`.
+
+[filesystem backend]: https://github.com/i18next/i18next-fs-backend
+
+## Features
+
+-   Fully ready for TypeScript!
+-   Includes ESM ready entrypoint
+-   Framework agnostic
+-   Includes convenience register for discord.js
+
+## Installation
+
+```sh
+yarn add -D @sapphire/plugin-i18next
+```
+
+---
+
+## Usage
+
+```typescript
+import '@sapphire/plugin-i18next/register';
+```
+
+And for discord.js:
+
+```typescript
+import '@sapphire/plugin-i18next/register-discordjs';
+```
+
+It is to be noted that unless you are using discord.js, which has the convenience register to extend the client, guild, channel and message methods for you, you will have to implement your own extensions.
+
+This is currently undocumented and not covered by guides, but will be in the future. For now, you may follow the structure of `register-discordjs.ts` if this is the case for you.
+
+## Sapphire i18next Documentation
+
+For the full @sapphire/plugin-i18next documentation please refer to the TypeDoc generated [documentation](https://sapphire-project.github.io/plugins/modules/_sapphire_plugin_i18next.html).
+
+## Buy us some doughnuts
+
+Sapphire Project is and always will be open source, even if we don't get donations. That being said, we know there are amazing people who may still want to donate just to show their appreciation. Thank you very much in advance!
+
+We accept donations through Open Collective, Ko-fi, Paypal, Patreon and GitHub Sponsorships. You can use the buttons below to donate through your method of choice.
+
+|   Donate With   |                                             Address                                              |
+| :-------------: | :----------------------------------------------------------------------------------------------: |
+| Open Collective |                    [Click Here](https://opencollective.com/sapphire-project)                     |
+|      Ko-fi      |                         [Click Here](https://ko-fi.com/sapphireproject)                          |
+|     Patreon     |                      [Click Here](https://www.patreon.com/sapphire_project)                      |
+|     PayPal      | [Click Here](https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=SP738BQTQQYZY) |
+
+## Contributors ✨
+
+Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/docs/en/emoji-key)):
+
+<!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
+<!-- prettier-ignore-start -->
+<!-- markdownlint-disable -->
+<table>
+  <tr>
+    <td align="center"><a href="https://favware.tech/"><img src="https://avatars3.githubusercontent.com/u/4019718?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Jeroen Claassens</b></sub></a><br /><a href="https://github.com/sapphire-project/plugins/commits?author=Favna" title="Code">💻</a> <a href="#infra-Favna" title="Infrastructure (Hosting, Build-Tools, etc)">🚇</a> <a href="#projectManagement-Favna" title="Project Management">📆</a></td>
+    <td align="center"><a href="https://quantumlytangled.com"><img src="https://avatars1.githubusercontent.com/u/7919610?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Nejc Drobnic</b></sub></a><br /><a href="https://github.com/sapphire-project/plugins/commits?author=QuantumlyTangled" title="Code">💻</a> <a href="https://github.com/sapphire-project/plugins/commits?author=QuantumlyTangled" title="Documentation">📖</a></td>
+    <td align="center"><a href="https://github.com/kyranet"><img src="https://avatars0.githubusercontent.com/u/24852502?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Antonio Román</b></sub></a><br /><a href="https://github.com/sapphire-project/plugins/commits?author=kyranet" title="Code">💻</a></td>
+    <td align="center"><a href="https://github.com/vladfrangu"><img src="https://avatars3.githubusercontent.com/u/17960496?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Vlad Frangu</b></sub></a><br /><a href="https://github.com/sapphire-project/plugins/pulls?q=is%3Apr+reviewed-by%3Avladfrangu" title="Reviewed Pull Requests">👀</a></td>
+    <td align="center"><a href="https://github.com/apps/depfu"><img src="https://avatars3.githubusercontent.com/in/715?v=4?s=100" width="100px;" alt=""/><br /><sub><b>depfu[bot]</b></sub></a><br /><a href="#maintenance-depfu[bot]" title="Maintenance">🚧</a></td>
+    <td align="center"><a href="https://github.com/apps/dependabot"><img src="https://avatars0.githubusercontent.com/in/29110?v=4?s=100" width="100px;" alt=""/><br /><sub><b>dependabot[bot]</b></sub></a><br /><a href="#maintenance-dependabot[bot]" title="Maintenance">🚧</a></td>
+    <td align="center"><a href="https://github.com/apps/allcontributors"><img src="https://avatars0.githubusercontent.com/in/23186?v=4?s=100" width="100px;" alt=""/><br /><sub><b>allcontributors[bot]</b></sub></a><br /><a href="https://github.com/sapphire-project/plugins/commits?author=allcontributors[bot]" title="Documentation">📖</a></td>
+  </tr>
+  <tr>
+    <td align="center"><a href="https://github.com/Nytelife26"><img src="https://avatars1.githubusercontent.com/u/22531310?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Tyler J Russell</b></sub></a><br /><a href="https://github.com/sapphire-project/plugins/commits?author=Nytelife26" title="Code">💻</a></td>
+  </tr>
+</table>
+
+<!-- markdownlint-restore -->
+<!-- prettier-ignore-end -->
+
+<!-- ALL-CONTRIBUTORS-LIST:END -->
+
+This project follows the [all-contributors](https://github.com/all-contributors/all-contributors) specification. Contributions of any kind welcome!

--- a/packages/prompt/jest.config.ts
+++ b/packages/prompt/jest.config.ts
@@ -1,0 +1,15 @@
+import type { Config } from '@jest/types';
+
+// eslint-disable-next-line @typescript-eslint/require-await
+export default async (): Promise<Config.InitialOptions> => ({
+	displayName: 'unit test',
+	preset: 'ts-jest',
+	testEnvironment: 'node',
+	testRunner: 'jest-circus/runner',
+	testMatch: ['<rootDir>/tests/**/*.test.ts'],
+	globals: {
+		'ts-jest': {
+			tsconfig: '<rootDir>/tests/tsconfig.json'
+		}
+	}
+});

--- a/packages/prompt/package.json
+++ b/packages/prompt/package.json
@@ -1,0 +1,82 @@
+{
+	"name": "@sapphire/plugin-prompt",
+	"version": "0.0.1",
+	"description": "Plugin for @sapphire/framework to support message prompts.",
+	"author": "@sapphire",
+	"license": "MIT",
+	"main": "dist/index.js",
+	"module": "dist/index.mjs",
+	"types": "dist/index.d.ts",
+	"exports": {
+		".": {
+			"import": "./dist/index.mjs",
+			"require": "./dist/index.js"
+		},
+		"./register": {
+			"import": "./register.mjs",
+			"require": "./register.js"
+		},
+		"./register-discordjs": {
+			"import": "./register-discordjs.mjs",
+			"require": "./register-discordjs.js"
+		}
+	},
+	"homepage": "https://github.com/sapphire-project/plugins/tree/main/packages/prompt",
+	"scripts": {
+		"test": "jest",
+		"lint": "eslint src tests --ext ts --fix",
+		"build": "tsc -b src",
+		"postbuild": "run-p esm:**",
+		"esm:register": "gen-esm-wrapper dist/register.js dist/register.mjs",
+		"esm:register-discordjs": "gen-esm-wrapper dist/register-discordjs.js dist/register-discordjs.mjs",
+		"esm:default": "gen-esm-wrapper dist/index.js dist/index.mjs",
+		"prepublishOnly": "yarn build"
+	},
+	"dependencies": {
+		"@sapphire/utilities": "^1.3.0"
+	},
+	"peerDependencies": {
+		"@sapphire/framework": "1.x",
+		"@sapphire/pieces": "1.x",
+		"discord.js": "^12.x"
+	},
+	"peerDependenciesMeta": {
+		"discord.js": {
+			"optional": true
+		}
+	},
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/sapphire-project/plugins.git",
+		"directory": "packages/i18next"
+	},
+	"files": [
+		"dist",
+		"!dist/*.tsbuildinfo",
+		"register.*",
+		"register-discordjs.*"
+	],
+	"engines": {
+		"node": ">=14",
+		"npm": ">=6"
+	},
+	"keywords": [
+		"sapphire-project",
+		"plugin",
+		"bot",
+		"typescript",
+		"ts",
+		"yarn",
+		"discord",
+		"sapphire",
+		"prompt",
+		"prompter",
+		"reactions"
+	],
+	"bugs": {
+		"url": "https://github.com/sapphire-project/plugins/issues"
+	},
+	"publishConfig": {
+		"access": "public"
+	}
+}

--- a/packages/prompt/package.json
+++ b/packages/prompt/package.json
@@ -33,7 +33,8 @@
 		"prepublishOnly": "yarn build"
 	},
 	"dependencies": {
-		"@sapphire/utilities": "^1.3.0"
+		"@sapphire/utilities": "^1.3.0",
+		"tslib": "^2.0.1"
 	},
 	"peerDependencies": {
 		"@sapphire/framework": "1.x",
@@ -48,7 +49,7 @@
 	"repository": {
 		"type": "git",
 		"url": "git+https://github.com/sapphire-project/plugins.git",
-		"directory": "packages/i18next"
+		"directory": "packages/prompt"
 	},
 	"files": [
 		"dist",

--- a/packages/prompt/register-discordjs.d.ts
+++ b/packages/prompt/register-discordjs.d.ts
@@ -1,0 +1,1 @@
+export * from './dist/register-discordjs';

--- a/packages/prompt/register-discordjs.js
+++ b/packages/prompt/register-discordjs.js
@@ -1,0 +1,4 @@
+/* eslint-disable @typescript-eslint/no-var-requires */
+const tslib = require('tslib');
+
+tslib.__exportStar(require('./dist/register-discordjs.js'), exports);

--- a/packages/prompt/register-discordjs.mjs
+++ b/packages/prompt/register-discordjs.mjs
@@ -1,0 +1,1 @@
+export * from './dist/register-discordjs.mjs';

--- a/packages/prompt/register.d.ts
+++ b/packages/prompt/register.d.ts
@@ -1,0 +1,1 @@
+export * from './dist/register';

--- a/packages/prompt/register.js
+++ b/packages/prompt/register.js
@@ -1,0 +1,4 @@
+/* eslint-disable @typescript-eslint/no-var-requires */
+const tslib = require('tslib');
+
+tslib.__exportStar(require('./dist/register.js'), exports);

--- a/packages/prompt/register.mjs
+++ b/packages/prompt/register.mjs
@@ -1,0 +1,1 @@
+export * from './dist/register.mjs';

--- a/packages/prompt/src/index.ts
+++ b/packages/prompt/src/index.ts
@@ -1,0 +1,1 @@
+export * from './lib/index';

--- a/packages/prompt/src/lib/PromptImplementation.ts
+++ b/packages/prompt/src/lib/PromptImplementation.ts
@@ -1,0 +1,74 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+import type { Client, Message, EmojiIdentifierResolvable, MessageReaction, User, CollectorFilter } from 'discord.js';
+import type { PromptBaseImplementation, PromptOptions, ResolvedPromptOptions } from './types/index';
+
+type Ctor = new (...args: any[]) => { client: Client };
+
+/**
+ * @since 1.0.0
+ * @returns An PromptBaseImplementation mixin which extends the Base parameter and fully implements {@link PromptBaseImplementation}.
+ * @param Base The class to use as the base for the implementation (e.g. a Discord library's Message object)
+ */
+export function PromptImplemented<BaseClass extends Ctor>(Base: BaseClass) {
+	/**
+	 * The class that defines the base / default implementations of the plugin.
+	 * This class is used to extend functions for Message & Channel
+	 * @since 1.0.0
+	 **/
+	return class PromptImplementation extends Base implements PromptBaseImplementation {
+		/**
+		 * @since 1.0.0
+		 * @see {@link PromptImplementation.createPromptOptions}
+		 */
+		public createPromptOptions(promptOptions?: PromptOptions): ResolvedPromptOptions {
+			const defaultOptions = {
+				confirm: '🇾',
+				cancel: '🇳',
+				timeout: 10000
+			};
+
+			return {
+				...defaultOptions,
+				...(this.client.options.prompt ?? {}),
+				...(promptOptions ?? {})
+			};
+		}
+
+		/**
+		 * @since 1.0.0
+		 * @see {@link PromptImplementation.createPromptFilter}
+		 */
+		public createPromptFilter(
+			confirm?: string | EmojiIdentifierResolvable,
+			cancel?: string | EmojiIdentifierResolvable,
+			userId?: string
+		): CollectorFilter {
+			return (reaction: MessageReaction, user: User) =>
+				[confirm, cancel].includes(reaction.emoji.name) && (!userId || user.id === userId) && !user.bot;
+		}
+
+		/**
+		 * @since 1.0.0
+		 * @see {@link PromptImplementation.attachPrompt}
+		 */
+		public async attachPrompt(message: Message, options?: PromptOptions, author?: User): Promise<boolean> {
+			const { confirm, cancel, timeout } = this.createPromptOptions(options);
+
+			await message.react(confirm);
+			await message.react(cancel);
+
+			const reactions = await message.awaitReactions(this.createPromptFilter(confirm, cancel, author?.id), {
+				max: 1,
+				time: timeout,
+				errors: ['time']
+			});
+
+			if (!reactions?.size) {
+				return false;
+			}
+
+			const reaction = reactions.first();
+			return reaction?.emoji?.name === confirm;
+		}
+	};
+}

--- a/packages/prompt/src/lib/index.ts
+++ b/packages/prompt/src/lib/index.ts
@@ -1,0 +1,2 @@
+export * from './types';
+export * from './PromptImplementation';

--- a/packages/prompt/src/lib/types/client.ts
+++ b/packages/prompt/src/lib/types/client.ts
@@ -1,0 +1,5 @@
+import type { PromptOptions } from '../../index';
+
+export interface PromptClientOptions {
+	prompt?: PromptOptions;
+}

--- a/packages/prompt/src/lib/types/implementations.ts
+++ b/packages/prompt/src/lib/types/implementations.ts
@@ -1,0 +1,58 @@
+import type {
+	StringResolvable,
+	APIMessage,
+	MessageOptions,
+	MessageAdditions,
+	EmojiIdentifierResolvable,
+	CollectorFilter,
+	Message,
+	User
+} from 'discord.js';
+import type { PromptOptions } from './options';
+
+export interface PromptBaseImplementation {
+	/**
+	 * @since 1.0.0
+	 * @return The options for the prompt
+	 */
+	createPromptOptions(options?: PromptOptions): PromptOptions;
+
+	/**
+	 * @since 1.0.0
+	 * @return The filter for awaitReactions function
+	 */
+	createPromptFilter(confirm?: string | EmojiIdentifierResolvable, cancel?: string | EmojiIdentifierResolvable, userId?: string): CollectorFilter;
+
+	/**
+	 * Function that attaches a prompt to a message
+	 * @since 1.0.0
+	 * @return A boolean of the prompt result
+	 */
+	attachPrompt(message: Message, options?: PromptOptions, author?: User): Promise<boolean>;
+}
+
+export interface PromptMessageImplementation {
+	/**
+	 * Function that sends a prompt message with the specified content.
+	 * @since 1.0.0
+	 * @return A boolean true for "confirm" and false for "cancel"
+	 */
+	replyPrompt(
+		content: StringResolvable | APIMessage,
+		options?: PromptOptions,
+		messageOptions?: (MessageOptions & { split?: false }) | MessageAdditions
+	): Promise<boolean>;
+}
+
+export interface PromptChannelImplementation {
+	/**
+	 * Function that sends a message for the channel with the translated key and values.
+	 * @since 1.0.0
+	 * @return A boolean true for "confirm" and false for "cancel"
+	 */
+	sendPrompt(
+		content: StringResolvable | APIMessage,
+		options?: PromptOptions,
+		messageOptions?: (MessageOptions & { split?: false }) | MessageAdditions
+	): Promise<boolean>;
+}

--- a/packages/prompt/src/lib/types/index.ts
+++ b/packages/prompt/src/lib/types/index.ts
@@ -1,0 +1,3 @@
+export * from './client';
+export * from './options';
+export * from './implementations';

--- a/packages/prompt/src/lib/types/options.ts
+++ b/packages/prompt/src/lib/types/options.ts
@@ -1,0 +1,49 @@
+import type { EmojiIdentifierResolvable } from 'discord.js';
+
+/**
+ * The options used for the plugin
+ * @since 1.0.0
+ */
+export interface PromptOptions {
+	/**
+	 * Default emoji used for confirm
+	 * @since 1.0.0
+	 */
+	confirm?: string | EmojiIdentifierResolvable;
+
+	/**
+	 * Default emoji used for cancel
+	 * @since 1.0.0
+	 */
+	cancel?: string | EmojiIdentifierResolvable;
+
+	/**
+	 * Default timeout in milliseconds
+	 * @since 1.0.0
+	 */
+	timeout?: number;
+}
+
+/**
+ * The options used for the attachPrompt function
+ * @since 1.0.0
+ */
+export interface ResolvedPromptOptions {
+	/**
+	 * Default emoji used for confirm
+	 * @since 1.0.0
+	 */
+	confirm: string | EmojiIdentifierResolvable;
+
+	/**
+	 * Default emoji used for cancel
+	 * @since 1.0.0
+	 */
+	cancel: string | EmojiIdentifierResolvable;
+
+	/**
+	 * Default timeout in milliseconds
+	 * @since 1.0.0
+	 */
+	timeout: number;
+}

--- a/packages/prompt/src/register-discordjs.ts
+++ b/packages/prompt/src/register-discordjs.ts
@@ -1,0 +1,80 @@
+import './register';
+import { PromptClientOptions, PromptOptions, PromptMessageImplementation, PromptChannelImplementation, PromptImplemented } from './index';
+import { MessageAdditions, MessageOptions, Structures, StringResolvable, APIMessage } from 'discord.js';
+
+export * from './register';
+
+class PromptMessage extends PromptImplemented(Structures.get('Message')) implements PromptMessageImplementation {
+	public async replyPrompt(
+		content: StringResolvable | APIMessage,
+		options?: PromptOptions,
+		messageOptions?: (MessageOptions & { split?: false }) | MessageAdditions
+	): Promise<boolean> {
+		const msg = await this.reply(content, messageOptions ?? {});
+		return this.attachPrompt(msg, options, this.author);
+	}
+}
+
+class PromptTextChannel extends PromptImplemented(Structures.get('TextChannel')) implements PromptChannelImplementation {
+	public async sendPrompt(
+		content: StringResolvable | APIMessage,
+		options?: PromptOptions,
+		messageOptions?: (MessageOptions & { split?: false }) | MessageAdditions
+	): Promise<boolean> {
+		const msg = await this.send(content, messageOptions ?? {});
+		return this.attachPrompt(msg, options);
+	}
+}
+
+class PromptDMChannel extends PromptImplemented(Structures.get('DMChannel')) implements PromptChannelImplementation {
+	public async sendPrompt(
+		content: StringResolvable | APIMessage,
+		options?: PromptOptions,
+		messageOptions?: (MessageOptions & { split?: false }) | MessageAdditions
+	): Promise<boolean> {
+		const msg = await this.send(content, messageOptions ?? {});
+		return this.attachPrompt(msg, options);
+	}
+}
+
+class PromptNewsChannel extends PromptImplemented(Structures.get('NewsChannel')) implements PromptChannelImplementation {
+	public async sendPrompt(
+		content: StringResolvable | APIMessage,
+		options?: PromptOptions,
+		messageOptions?: (MessageOptions & { split?: false }) | MessageAdditions
+	): Promise<boolean> {
+		const msg = await this.send(content, messageOptions ?? {});
+		return this.attachPrompt(msg, options);
+	}
+}
+
+Structures.extend('Message', () => PromptMessage);
+Structures.extend('TextChannel', () => PromptTextChannel);
+Structures.extend('DMChannel', () => PromptDMChannel);
+Structures.extend('NewsChannel', () => PromptNewsChannel);
+
+declare module 'discord.js' {
+	export interface Message extends PromptMessageImplementation {
+		/**
+		 * @see {@link PromptMessageImplementation.replyPrompt}
+		 */
+		replyPrompt(
+			content: StringResolvable | APIMessage,
+			options?: PromptOptions,
+			messageOptions?: (MessageOptions & { split?: false }) | MessageAdditions
+		): Promise<boolean>;
+	}
+
+	export interface Channel extends PromptChannelImplementation {
+		/**
+		 * @see {@link PromptChannelImplementation.sendPrompt}
+		 */
+		sendPrompt(
+			content: StringResolvable | APIMessage,
+			options?: PromptOptions,
+			messageOptions?: (MessageOptions & { split?: false }) | MessageAdditions
+		): Promise<boolean>;
+	}
+
+	export interface ClientOptions extends PromptClientOptions {}
+}

--- a/packages/prompt/src/register.ts
+++ b/packages/prompt/src/register.ts
@@ -1,0 +1,6 @@
+import type { PromptClientOptions } from './lib';
+import '@sapphire/framework';
+
+declare module '@sapphire/framework' {
+	export interface SapphireClientOptions extends PromptClientOptions {}
+}

--- a/packages/prompt/src/tsconfig.json
+++ b/packages/prompt/src/tsconfig.json
@@ -1,0 +1,11 @@
+{
+	"extends": "../../../tsconfig.base.json",
+	"compilerOptions": {
+		"rootDir": "./",
+		"outDir": "../dist",
+		"composite": true,
+		"preserveConstEnums": true,
+		"tsBuildInfoFile": "../dist/.tsbuildinfo"
+	},
+	"include": ["."]
+}

--- a/packages/prompt/tests/tsconfig.json
+++ b/packages/prompt/tests/tsconfig.json
@@ -1,0 +1,10 @@
+{
+	"extends": "../../../tsconfig.base.json",
+	"compilerOptions": {
+		"rootDir": "./",
+		"noEmit": true,
+		"incremental": false
+	},
+	"include": ["."],
+	"references": [{ "path": "../src" }]
+}

--- a/packages/prompt/tsconfig.eslint.json
+++ b/packages/prompt/tsconfig.eslint.json
@@ -1,0 +1,4 @@
+{
+	"extends": "./tsconfig.json",
+	"include": ["src", "tests"]
+}

--- a/packages/prompt/tsconfig.json
+++ b/packages/prompt/tsconfig.json
@@ -1,0 +1,11 @@
+{
+	"extends": "../../tsconfig.base.json",
+	"compilerOptions": {
+		"outDir": "dist",
+		"rootDir": "src",
+		"composite": true,
+		"preserveConstEnums": true,
+		"tsBuildInfoFile": "./dist/.tsbuildinfo"
+	},
+	"include": ["src"]
+}


### PR DESCRIPTION
A plugin for simple prompting a user for true/false.

Want to extend this in the future with options for more reactions and returning that reaction etc.

Accepts the same options as a normal `reply` or `send` function. But adds the reactions & listens to them.
![image](https://user-images.githubusercontent.com/5418114/103961317-88d9a600-5154-11eb-918c-aaf5fcebc6d5.png)

PS. Still requires tests, but would like some help testing a case like this..