### PR TITLE
fix(api): fixed how domain is retrieved for cookies

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -28,7 +28,9 @@
 		"prepublishOnly": "yarn build"
 	},
 	"dependencies": {
+		"@types/psl": "^1.1.0",
 		"node-fetch": "^2.6.1",
+		"psl": "^1.8.0",
 		"tslib": "^2.1.0"
 	},
 	"peerDependencies": {

--- a/packages/api/src/lib/structures/api/CookieStore.ts
+++ b/packages/api/src/lib/structures/api/CookieStore.ts
@@ -30,8 +30,7 @@ export class CookieStore extends Map<string, string> {
 			this.set(key, value);
 		}
 
-		const { host } = this.request.headers;
-		const [splitHost] = host?.split(':') ?? [''];
+		const [splitHost] = this.request.headers.host?.split(':') ?? [''];
 
 		this.domain = this.getHostDomain(splitHost);
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1838,6 +1838,11 @@
   resolved "https://registry.yarnpkg.com/@types/prettier/-/prettier-2.2.3.tgz#ef65165aea2924c9359205bf748865b8881753c0"
   integrity sha512-PijRCG/K3s3w1We6ynUKdxEc5AcuuH3NBmMDP8uvKVp6X43UY7NQlTzczakXP3DJR0F4dfNQIGjU2cUeRYs2AA==
 
+"@types/psl@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@types/psl/-/psl-1.1.0.tgz#390c5df1613b166ce3c3eb9fda4d93dc3eeec7b5"
+  integrity sha512-HhZnoLAvI2koev3czVPzBNRYvdrzJGLjQbWZhqFmS9Q6a0yumc5qtfSahBGb5g+6qWvA8iiQktqGkwoIXa/BNQ==
+
 "@types/stack-utils@^2.0.0":
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-2.0.0.tgz#7036640b4e21cc2f259ae826ce843d277dad8cff"
@@ -6886,7 +6891,7 @@ protocols@^1.1.0, protocols@^1.4.0:
   resolved "https://registry.yarnpkg.com/protocols/-/protocols-1.4.8.tgz#48eea2d8f58d9644a4a32caae5d5db290a075ce8"
   integrity sha512-IgjKyaUSjsROSO8/D49Ab7hP8mJgTYcqApOqdPhLoPxAplXmkp+zRvsrSQjFn5by0rhm4VH0GAUELIPpx7B1yg==
 
-psl@^1.1.28:
+psl@^1.1.28, psl@^1.8.0:
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/psl/-/psl-1.8.0.tgz#9326f8bcfb013adcc005fdff056acce020e51c24"
   integrity sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ==


### PR DESCRIPTION
For Skyra the cookie is fetched for `api.skyra.pw` because that's where we have the API. However the websocket uses `box.skyra.pw`. Because these are different the browser ended up not sending the cookie with WebSocket requests, causing our backend to immediately `Unauthorized`. Looking at other cookies it actually had to be `.skyra.pw`. This fixes it.

Also should be noted that while `psl` in its current state is good enough, I opened a PR to the repo to improve it: https://github.com/lupomontero/psl/pull/273